### PR TITLE
feat(wsl): manage bashrc and profile, drop stale atuin env loader

### DIFF
--- a/home/.chezmoiignore.tmpl
+++ b/home/.chezmoiignore.tmpl
@@ -34,6 +34,12 @@ Library
 .local/share/fonts
 {{ end }}
 
+# Bash login files are WSL-only (other Linux uses distro defaults; Mac uses zsh)
+{{ if not .is_wsl }}
+.bashrc
+.profile
+{{ end }}
+
 # Ignore non-Windows files.
 {{ if ne .chezmoi.os "windows" }}
 .chezmoiscripts/windows/**

--- a/home/dot_bashrc.tmpl
+++ b/home/dot_bashrc.tmpl
@@ -1,0 +1,17 @@
+{{- /* WSL Ubuntu .bashrc — managed by chezmoi for WSL only. Tool installers
+       (atuin/deno/console-ninja/pnpm) may append lines after apply; that
+       drift is expected. The bail-early guard keeps non-interactive `bash -lc`
+       silent regardless of what installers add. */ -}}
+# ~/.bashrc: executed by bash(1) for non-login shells.
+
+# If not running interactively, don't do anything
+case $- in
+    *i*) ;;
+      *) return;;
+esac
+
+[[ -f ~/.fzf.bash ]] && source ~/.fzf.bash
+[[ -f ~/.bash-preexec.sh ]] && source ~/.bash-preexec.sh
+[[ -f "${HOME}/.deno/env" ]] && . "${HOME}/.deno/env"
+command -v atuin >/dev/null 2>&1 && eval "$(atuin init bash)"
+[[ -d "${HOME}/.console-ninja/.bin" ]] && PATH="${HOME}/.console-ninja/.bin:${PATH}"

--- a/home/dot_profile.tmpl
+++ b/home/dot_profile.tmpl
@@ -1,0 +1,23 @@
+{{- /* WSL Ubuntu .profile — managed by chezmoi for WSL only. Mirror of the
+       Ubuntu default plus mise/deno env loaders. atuin's old curl-installer
+       line is intentionally absent; atuin now lives in mise. */ -}}
+# ~/.profile: executed by the command interpreter for login shells.
+# This file is not read by bash(1), if ~/.bash_profile or ~/.bash_login exists.
+
+# if running bash
+if [ -n "$BASH_VERSION" ]; then
+    if [ -f "$HOME/.bashrc" ]; then
+        . "$HOME/.bashrc"
+    fi
+fi
+
+if [ -d "$HOME/bin" ]; then
+    PATH="$HOME/bin:$PATH"
+fi
+
+if [ -d "$HOME/.local/bin" ]; then
+    PATH="$HOME/.local/bin:$PATH"
+fi
+
+[[ -f "${HOME}/.local/share/mise/env" ]] && . "${HOME}/.local/share/mise/env"
+[[ -f "${HOME}/.deno/env" ]] && . "${HOME}/.deno/env"


### PR DESCRIPTION
## Summary
- Add `home/dot_bashrc.tmpl` with the standard non-interactive bail-early guard, so `bash -lc` invocations stop emitting `bind: warning: line editing not enabled` from atuin's emitted init script.
- Add `home/dot_profile.tmpl` mirroring the Ubuntu default plus mise + deno env loaders. Drops the stale `. "$HOME/.atuin/bin/env"` line — atuin now lives in mise and that path no longer exists.
- Gate both files via `.chezmoiignore.tmpl` on `.is_wsl`. Non-WSL Linux keeps distro defaults; Mac and Windows are unaffected.

Tool installers (atuin / deno / pnpm / console-ninja) may still append lines to these files after `chezmoi apply`. That drift is acceptable; the bail-early guard keeps non-interactive shells silent regardless of what installers add.

## Test plan
- [x] `chezmoi execute-template` renders both files cleanly on Mac
- [ ] On work-eth WSL: `chezmoi diff` shows the two-file replacement
- [ ] `chezmoi apply`
- [ ] `exec bash -l` — verify no `.bashrc:754` warning and no `.atuin/bin/env not found` error
- [ ] `chezmoi apply` again — confirm idempotent