### PR TITLE
fix(topgrade): run skills updater via pnx, not npx

### DIFF
--- a/home/.chezmoitemplates/topgrade.toml
+++ b/home/.chezmoitemplates/topgrade.toml
@@ -111,7 +111,10 @@ auto_retry = 1
 #
 # agent-skills: chezmoi's run_onchange install-skills script ADDS declared
 # skills (fires on skills.yaml change); topgrade owns UPDATING them.
-agent-skills = "npx -y skills update -g -y"
+# Invoke via `pnx`, not `npx`: the skills package declares
+# devEngines.packageManager = pnpm, so npm trips EBADDEVENGINES on a
+# name mismatch. pnx (alias of pnpm dlx) runs it under pnpm and satisfies it.
+agent-skills = "pnx skills update -g -y"
 # tv-channels: pull the community channel set. Moved out of chezmoi apply
 # (was run_before_05-update-tv-channels) so apply stays fast; tv skips
 # channels that already exist, chezmoi still owns custom overrides.


### PR DESCRIPTION
## Problem

`topgrade --only custom_commands` failed the `agent-skills` step:

```
npm error code EBADDEVENGINES
npm error EBADDEVENGINES Invalid name "pnpm" does not match "npm" for "packageManager"
required: { name: 'pnpm', version: '>=11.0.0 <12.0.0', onFail: 'download' }
```

The `skills` package (vercel-labs/skills) declares `devEngines.packageManager = pnpm`. The custom command invoked it with `npx`, which runs under **npm**, so npm 11 hard-fails on the package-manager name mismatch.

## Fix

Invoke via `pnx` (alias of `pnpm dlx`) instead of `npx`, so it runs under pnpm (11.2.1 here) and satisfies the constraint.

```
-agent-skills = "npx -y skills update -g -y"
+agent-skills = "pnx skills update -g -y"
```

## Verification

Real `topgrade --only custom_commands` run: `agent-skills: OK`, all global skills up to date, no EBADDEVENGINES.

Follow-up to #10 (which placed this config at `%APPDATA%` on Windows).