### PR TITLE
chore(windows): install zen via winget --location, not scoop

### DIFF
--- a/home/.chezmoidata/scoop.toml
+++ b/home/.chezmoidata/scoop.toml
@@ -40,7 +40,6 @@ buckets = []
 # relocated work setups.
 packages = [
   "zed",
-  "zen-browser",
   "wezterm",
 ]
 # admin_packages install at machine scope and require UAC. Handled

--- a/home/.chezmoidata/winget.toml
+++ b/home/.chezmoidata/winget.toml
@@ -36,4 +36,6 @@ packages = [
 # mode (Inno, machine-scope MSI) will be rejected by winget — those
 # packages must go in scoop.toml [scoop.work] instead.
 [winget.work]
-packages = []
+packages = [
+  "Zen-Team.Zen-Browser",
+]


### PR DESCRIPTION
## What

Move Zen Browser from `[scoop.work]` to `[winget.work]` so relocated work boxes install it through winget slot 08 (`--scope user --location <tools_root>\tools`) instead of scoop slot 10.

## Why

Zen's winget manifest `Zen-Team.Zen-Browser` is a generic `exe` that accepts winget's `--location` passthrough. Verified with the exact work install flags — install lands inside the whitelisted tools_root, no scoop needed.

## What stays in scoop

`zed` and `wezterm` both probed as Inno **machine-scope** manifests. With `--scope user --location` they fail fast — `winget show` shows no user scope, and a live probe returned exit `16` (`NO_APPLICABLE_INSTALLER`). They keep their scoop entries.

## Verify

```
chezmoi execute-template '{{ range .winget.work.packages }}{{ . }} {{ end }}'
# -> Zen-Team.Zen-Browser
```