### PR TITLE
fix(windows): codify Pester test path to stop whitelist drift

### DIFF
--- a/home/.chezmoiscripts/windows/run_onchange_before_05-set-env-vars.ps1.tmpl
+++ b/home/.chezmoiscripts/windows/run_onchange_before_05-set-env-vars.ps1.tmpl
@@ -48,6 +48,14 @@ $envVars = [ordered]@{
     # proto: toolchain manager. Default ~/.proto sits in the user profile,
     # where endpoint security blocks executing the tool binaries it manages.
     'PROTO_HOME'            = '{{ .directories.tools_root }}/.proto'
+    # PESTER_MODULE_ROOT: whitelisted home for PowerShell modules whose DLLs
+    # endpoint security blocks under the user profile (Pester.dll fails to load
+    # from Documents\PowerShell\Modules with "Should operator 'Be' is not
+    # registered"). The test runner (tests/Invoke.ps1) imports Pester by
+    # explicit path from here, because PSModulePath search resolves the blocked
+    # profile copy first. Generic var keeps the machine-specific path out of the
+    # unmanaged tests/ tree.
+    'PESTER_MODULE_ROOT'    = '{{ .directories.tools_root }}/PSModules'
 {{- end }}
 }
 

--- a/tests/Invoke.ps1
+++ b/tests/Invoke.ps1
@@ -1,0 +1,30 @@
+#!/usr/bin/env pwsh
+# Pester test runner.
+#
+# On work-Windows (relocated) machines, endpoint security blocks loading
+# Pester.dll from the default user-profile module dir
+# (Documents\PowerShell\Modules), surfacing as "Should operator 'Be' is not
+# registered". A whitelisted copy lives under the relocation tools_root, and
+# the relocation env-var script exports its path as PESTER_MODULE_ROOT. Import
+# Pester by explicit path from there, because PSModulePath search resolves the
+# blocked profile copy first regardless of ordering.
+#
+# On personal machines PESTER_MODULE_ROOT is unset and Pester loads normally
+# from PSModulePath.
+#
+# Run:  pwsh -NoProfile -File ./tests/Invoke.ps1
+[CmdletBinding()]
+param(
+    [string]$Path = $PSScriptRoot
+)
+
+$ErrorActionPreference = 'Stop'
+
+$root = $env:PESTER_MODULE_ROOT
+if ($root -and (Test-Path (Join-Path $root 'Pester'))) {
+    Import-Module (Join-Path $root 'Pester') -ErrorAction Stop
+} else {
+    Import-Module Pester -ErrorAction Stop
+}
+
+Invoke-Pester -Path $Path -Output Detailed

--- a/tests/windows-relocation.Tests.ps1
+++ b/tests/windows-relocation.Tests.ps1
@@ -1,7 +1,9 @@
 #requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
 # Tests for the windows-relocation template partial. The partial is pure
 # PowerShell (no chezmoi template syntax) so it dot-sources directly.
-# Run: pwsh -NoProfile -Command "Invoke-Pester -Path ./tests"
+# Run: pwsh -NoProfile -File ./tests/Invoke.ps1
+# (the runner imports Pester from the whitelisted PESTER_MODULE_ROOT on
+# relocated machines; see tests/Invoke.ps1)
 
 # The partial is extensionless (chezmoi .chezmoitemplates convention), and
 # PowerShell's dot-source operator only loads .ps1 files - so load it as a


### PR DESCRIPTION
## Problem

Endpoint security blocks loading Pester.dll from the default user-profile module dir (`Documents\PowerShell\Modules`), surfacing as `Should operator 'Be' is not registered`. The workaround keeps a whitelisted Pester copy under `tools_root`, but nothing pinned its location, so ad-hoc per-session copies accreted (two diverging copies under different dirs).

## Fix

- The relocation env-var script exports the whitelisted module root as `PESTER_MODULE_ROOT` (= `tools_root/PSModules`, generic in source).
- New `tests/Invoke.ps1` imports Pester by explicit path from there before running the suite. Explicit-path import is required because PSModulePath search resolves the blocked profile copy first regardless of ordering.
- Machine-specific path stays out of the unmanaged `tests/` tree via the env var.

## Verification

`pwsh -NoProfile -File ./tests/Invoke.ps1` -> 11/11 pass, loading Pester from the whitelisted copy.