### PR TITLE
fix(winget): install scope-less packages (Zen) bare via no_scope list

### DIFF
--- a/home/.chezmoidata/winget.toml
+++ b/home/.chezmoidata/winget.toml
@@ -20,6 +20,21 @@ packages = [
   "arndawg.zellij-windows",
 ]
 
+# Install-without-scope exceptions (cross-cutting; orthogonal to the section
+# lists - keep the package in packages/work/personal for selection, list its
+# ID here to change HOW it installs). These manifests ship a scope-less
+# installer (a bare .exe with no Scope declared), so the relocated default
+# `--scope user --location` filters out the only installer ("No applicable
+# installer found"; verified: `winget show <id> --scope user`). IDs here
+# install with bare flags and land in their default location. Safe for
+# browsers/GUI apps - the endpoint-security exec block targets dev/sandbox
+# binaries under the profile, not these.
+# (Must stay above the [winget.*] sub-tables: a bare key after a sub-table
+# header would bind to that sub-table in TOML.)
+no_scope = [
+  "Zen-Team.Zen-Browser",
+]
+
 # Personal-only additions (gated by .personal in the install script).
 # Machine-scope installers (Inno/MSI) are fine here — personal boxes
 # have admin and no whitelist constraint, so UAC prompts are acceptable.
@@ -32,9 +47,10 @@ packages = [
 
 # Work-only additions (gated by .work). The install script passes
 # --scope user --location <tools_root>\tools so portable manifests land
-# inside the whitelisted path. Manifests that don't support portable
-# mode (Inno, machine-scope MSI) will be rejected by winget — those
-# packages must go in scoop.toml [scoop.work] instead.
+# inside the whitelisted path. Manifests rejected by those flags have two
+# escape hatches: list the ID in `no_scope` above (installs bare, default
+# location - for browsers/GUI apps like Zen, whose exe has no user scope),
+# or move it to scoop.toml [scoop.work] (Inno/machine-scope MSI dev tools).
 [winget.work]
 packages = [
   "Zen-Team.Zen-Browser",

--- a/home/.chezmoiscripts/windows/run_onchange_before_08-install-winget-pkgs.ps1.tmpl
+++ b/home/.chezmoiscripts/windows/run_onchange_before_08-install-winget-pkgs.ps1.tmpl
@@ -13,12 +13,12 @@
 #     scope. Inno/MSI installers prompt UAC (acceptable on personal).
 #   - Work + relocated tools_root: pass --scope user --location to keep
 #     portable manifests inside the whitelisted dev path. Non-portable
-#     manifests will reject these flags — those packages belong in
-#     scoop.toml [scoop.work], not here.
+#     manifests will reject these flags - list them in winget.toml
+#     no_scope (installs bare) or move dev tools to scoop.toml [scoop.work].
 
 $ErrorActionPreference = 'Stop'
 
-# Probe launch, not file presence — MSIX alias exists but session 0 can't activate it.
+# Probe launch, not file presence - MSIX alias exists but session 0 can't activate it.
 $wingetOk = $false
 try { & winget --version *>$null; $wingetOk = ($LASTEXITCODE -eq 0) } catch {}
 if (-not $wingetOk) {
@@ -47,6 +47,14 @@ if ($wingetPackages.Count -eq 0) {
     exit 0
 }
 
+# IDs whose manifest has no user-scoped installer; installed with bare flags
+# even on relocated machines (see winget.toml [winget] no_scope).
+$noScope = @(
+{{- range .winget.no_scope }}
+    '{{ . }}'
+{{- end }}
+)
+
 {{- if .relocated }}
 $workLocation = '{{ .directories.tools_root }}\tools' -replace '/', '\'
 if (-not (Test-Path $workLocation)) {
@@ -68,9 +76,16 @@ foreach ($id in $wingetPackages) {
 
     Write-Host "[Install] winget install $id" -ForegroundColor Blue
 {{- if .relocated }}
-    & winget install --id $id --exact --source winget --disable-interactivity `
-        --accept-package-agreements --accept-source-agreements `
-        --scope user --location $workLocation
+    # Scope-less installers (see $noScope) reject --scope user --location and
+    # winget reports "No applicable installer found"; install them bare.
+    if ($noScope -contains $id) {
+        & winget install --id $id --exact --source winget --disable-interactivity `
+            --accept-package-agreements --accept-source-agreements
+    } else {
+        & winget install --id $id --exact --source winget --disable-interactivity `
+            --accept-package-agreements --accept-source-agreements `
+            --scope user --location $workLocation
+    }
 {{- else }}
     & winget install --id $id --exact --source winget --disable-interactivity `
         --accept-package-agreements --accept-source-agreements


### PR DESCRIPTION
## Problem (follow-up to #12)

#12 moved Zen to `[winget.work]` but kept the relocated install flags `--scope user --location`. On a **relocated** work machine those flags fail for Zen:

```
[ERROR] winget install Zen-Team.Zen-Browser exit -1978335216
No applicable installer found; see logs for more details.
```

Zen's manifest is a scope-less exe (no `Scope` declared), so `--scope user` filters out the only installer. Reproducible non-destructively:

```
winget show Zen-Team.Zen-Browser --scope user   # -> "No applicable installer found"
winget show Zen-Team.Zen-Browser                 # -> installer present (exe)
```

(It doesn't surface once Zen is already installed, because the `winget list` idempotency check skips it — but a fresh relocated machine hits it.)

## Fix

Add a cross-cutting `no_scope` list to `winget.toml`. IDs listed there install with **bare** flags (default location) even when relocated, while staying in their section list for selection. The install script branches per-package on membership.

Safe for browsers/GUI apps — the endpoint-security exec block targets dev/sandbox binaries under the profile, not these.

Also strips two stray em-dashes from the script (chezmoi PS templates parse as CP1252 and must stay ASCII).

## Verification

- `chezmoi execute-template` renders `$noScope = @('Zen-Team.Zen-Browser')` and the per-package branch.
- Earlier apply with the bare path installed Zen successfully (`winget install ... completed`).
- Script is ASCII-clean (0 non-ASCII bytes).