### PR TITLE
refactor(1password): derive signer path from %LOCALAPPDATA%

### DIFF
--- a/home/.chezmoi.toml.tmpl
+++ b/home/.chezmoi.toml.tmpl
@@ -79,12 +79,6 @@
 {{-   $dev_computer = promptBoolOnce . "dev_computer" "Install dev tools on this machine?" -}}
 {{- end -}}
 
-{{/* WSL: Windows username for /mnt/c/Users/<name> interop paths (op-ssh-sign-wsl, etc.) */}}
-{{- $windows_username := "" -}}
-{{- if and $is_wsl (not $ephemeral) -}}
-{{-   $windows_username = promptStringOnce . "windows_username" "Windows username (for /mnt/c/Users/<name> interop paths)" -}}
-{{- end -}}
-
 {{- $email := "" -}}
 {{- if $opVault -}}
 {{-   if lookPath "op" -}}
@@ -157,7 +151,6 @@
   work = {{ $work }}
   relocated = {{ $relocated }}
   is_wsl = {{ $is_wsl }}
-  windows_username = {{ $windows_username | quote }}
   dev_computer = {{ $dev_computer }}
   hostname = {{ $hostname | quote }}
   personal = {{ $personal }}

--- a/home/dot_config/git/azure-signing.inc.tmpl
+++ b/home/dot_config/git/azure-signing.inc.tmpl
@@ -1,13 +1,16 @@
 {{- if and .work .is_wsl -}}
+{{- $localappdata := output "/mnt/c/Windows/System32/cmd.exe" "/c" "echo %LOCALAPPDATA%" | trim -}}
+{{- $localappdata = output "wslpath" "-u" $localappdata | trim -}}
 # Included ONLY by Azure DevOps repos, via the includeIf rules in
 # ~/.config/git/config. Signs commits with the 1Password-held SSH key using the
 # Windows-side signer over WSL interop — no native Linux op required.
-# Signer path is 1Password's WSL build (app 8.11.18+); username hardcoded to the
-# single Windows user on this work box.
+# Signer path is 1Password's WSL build (app 8.11.18+). Resolved from the Windows
+# %LOCALAPPDATA% (via cmd.exe interop, translated with wslpath) so it follows a
+# relocated profile or non-C: drive instead of assuming C:\Users\<name>.
 [gpg]
 	format = ssh
 [gpg "ssh"]
-	program = "/mnt/c/Users/AndrewCl/AppData/Local/Microsoft/WindowsApps/op-ssh-sign-wsl.exe"
+	program = "{{ joinPath $localappdata "Microsoft" "WindowsApps" "op-ssh-sign-wsl.exe" }}"
 [user]
 	signingkey = ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMhN9/EmrCcRRlwlG+vR5dBRHNPDGSmqy1+TZMoBp6am
 [commit]


### PR DESCRIPTION
## Summary

Follow-up to #16. Removes the hardcoded Windows username from the Azure DevOps commit-signing config.

- Drop the `windows_username` chezmoi data var — it had a single consumer.
- Derive the `op-ssh-sign-wsl.exe` signer path inline in `azure-signing.inc` from the Windows `%LOCALAPPDATA%`: read via `cmd.exe` interop, translate with `wslpath`, assemble with `joinPath`.
- Follows a relocated profile or non-C: drive instead of assuming `C:\Users\<name>`.

## Why not a native chezmoi function

On WSL `chezmoi.os = linux`, so `.chezmoi.windowsAppData` is absent (Windows-only), and `%LOCALAPPDATA%` isn't in the linux env or `WSLENV`. Interop is the only way to read it.
