### PR TITLE
Azure DevOps credential architecture + television readmes channel

### DIFF
--- a/docs/github-auth-architecture.md
+++ b/docs/github-auth-architecture.md
@@ -115,7 +115,10 @@ git push → SSH (1Password SSH Agent) → op://Employee/SSH Key
 ```
 git push → SSH (needs own key or 1Password interop)
            HTTPS to github.com → gh auth git-credential (native gh via mise)
-           HTTPS to dev.azure.com → git-credential-manager.exe via interop
+           HTTPS to dev.azure.com → GCM.exe via interop  (PRIMARY: cached AAD
+                                    token from Windows Credential Manager)
+                                    ↓ falls through only if GCM yields no token
+                                    az-CLI mint helper (HEADLESS FALLBACK)
 ```
 
 **`git/config.tmpl` credential setup:**
@@ -133,12 +136,38 @@ git push → SSH (needs own key or 1Password interop)
     helper = manager        # Git Credential Manager (cask: git-credential-manager)
     useHttpPath = true
 
-# WSL2 work only (line 146-151):
+# WSL2 work only — GCM primary + az-CLI mint fallback (chained):
 [credential]
-    helper = /mnt/c/Program Files/Git/mingw64/bin/git-credential-manager.exe
+    helper = /mnt/c/Program Files/Git/mingw64/bin/git-credential-manager.exe   # PRIMARY
 [credential "https://dev.azure.com"]
-    useHttpPath = true
+    helper = ~/.git-azdo-helper.sh        # FALLBACK (managed; gated work+WSL)
+    # useHttpPath/azreposCredentialType come from the shared $azure block above
 ```
+
+**WSL2 Azure DevOps credential chain (verified 2026-06-15):**
+
+- **GCM *does* auth Azure from WSL2** — contrary to an earlier (now removed)
+  belief that it couldn't. The catch is `useHttpPath = true`: it feeds GCM the
+  org path so GCM can resolve the org and return the cached AAD token from
+  Windows Credential Manager. Without it, GCM errors with "Cannot determine the
+  organization name." This is the only Azure-specific config GCM needs (it's the
+  exact requirement in [MS Learn: Git on WSL](https://learn.microsoft.com/en-us/windows/wsl/tutorials/wsl-git)).
+- **Why a fallback at all:** GCM serves a *cached* token headlessly, but on
+  expiry it needs an interactive Windows sign-in dialog. A headless session
+  (e.g. `ssh work-wsl` from the Mac) can't render that dialog, so the push
+  stalls. `~/.git-azdo-helper.sh` mints a fresh AAD token non-interactively from
+  the cached `az` CLI session, closing that gap. Its `--resource` GUID
+  (`499b84ac-…`) is the **public** Azure DevOps first-party app id, not a secret.
+- **FOOTGUN — never `helper =` (empty reset) before the az-mint helper.** A
+  reset clears the *inherited global GCM helper* from the Azure chain, leaving
+  az-mint as the *only* helper. That's the bug that once forced az-only auth and
+  read as "can't push via GCM." The fallback must be appended **after** the
+  global GCM line (file order = chain order; git uses the first helper that
+  returns creds), with **no reset**.
+- The mint script lives untracked at `~/.git-azdo-helper.sh` historically; it is
+  now chezmoi-managed (`executable_dot_git-azdo-helper.sh`, gated to work+WSL in
+  `.chezmoiignore.tmpl`). Per-machine `config.local` no longer overrides Azure
+  auth — the template owns the chain.
 
 The `gh auth git-credential` path is resolved dynamically via `lookPath "gh"` at `chezmoi apply` time. When gh moves from scoop to mise, the path updates automatically on next apply.
 

--- a/docs/github-auth-architecture.md
+++ b/docs/github-auth-architecture.md
@@ -101,6 +101,7 @@ git push → SSH (1Password SSH Agent) → op://Private/SSH Key
            OR
            HTTPS → osxkeychain credential helper
            HTTPS to github.com → gh auth git-credential
+           HTTPS to dev.azure.com → Git Credential Manager (Microsoft OAuth, cached in osxkeychain)
 ```
 
 ### Windows (work)
@@ -124,9 +125,13 @@ git push → SSH (needs own key or 1Password interop)
 [credential "https://github.com"]
     helper = !"<gh binary path>" auth git-credential
 
-# macOS only (line 133-135):
+# macOS only:
 [credential]
     helper = osxkeychain
+    azreposCredentialType = oauth
+[credential "https://dev.azure.com"]
+    helper = manager        # Git Credential Manager (cask: git-credential-manager)
+    useHttpPath = true
 
 # WSL2 work only (line 146-151):
 [credential]

--- a/home/.chezmoiignore.tmpl
+++ b/home/.chezmoiignore.tmpl
@@ -47,6 +47,14 @@ Library
 .wezterm.lua
 {{ end }}
 
+# az-CLI Azure DevOps token-mint helper is the headless fallback in the WSL2
+# credential chain (see dot_config/git/config.tmpl). Only work WSL2 needs it;
+# everywhere else (mac, personal WSL, Windows) uses GCM alone, so leave any
+# stray local copy unmanaged there.
+{{ if not (and .work .is_wsl) }}
+.git-azdo-helper.sh
+{{ end }}
+
 # Ignore non-Windows files.
 {{ if ne .chezmoi.os "windows" }}
 .chezmoiscripts/windows/**

--- a/home/.chezmoiscripts/darwin/run_onchange_before_10-install-brew-packages.sh.tmpl
+++ b/home/.chezmoiscripts/darwin/run_onchange_before_10-install-brew-packages.sh.tmpl
@@ -38,6 +38,7 @@ set -eufo pipefail
     "font-monaspace"
     "font-symbols-only-nerd-font"
     "ghostty"
+    "git-credential-manager"
     "hammerspoon"
     "hazel"
     "iina"

--- a/home/dot_config/git/config.tmpl
+++ b/home/dot_config/git/config.tmpl
@@ -123,10 +123,6 @@
 [trim]
 	bases = main,gh-pages
 
-{{- if .personal }}
-[url "git@github.com:Drewtopia/"]
-	insteadOf = https://github.com/Drewtopia/
-{{- end }}
 {{- /* Find gh: try lookPath first, fall back to mise shim */ -}}
 {{- $ghPath := lookPath "gh" }}
 {{- if not $ghPath }}
@@ -163,6 +159,8 @@
 	helper = osxkeychain
 {{- end }}
 {{- if .personal }}
+[url "git@github.com:Drewtopia/"]
+	insteadOf = https://github.com/Drewtopia/
 [gpg]
 	format = ssh
 [user]

--- a/home/dot_config/git/config.tmpl
+++ b/home/dot_config/git/config.tmpl
@@ -152,6 +152,14 @@
 {{ if eq .chezmoi.os "darwin" -}}
 [credential]
 	helper = osxkeychain
+	azreposCredentialType = oauth
+# Azure DevOps on macOS: Git Credential Manager (Microsoft OAuth, token cached
+# in osxkeychain), consistent with the GCM setup on Windows/WSL. Empty `helper =`
+# resets the chain so osxkeychain doesn't also fire for dev.azure.com.
+[credential "https://dev.azure.com"]
+	helper =
+	helper = manager
+	useHttpPath = true
 {{- end }}
 {{- if .personal }}
 [gpg]
@@ -170,6 +178,7 @@
 # Windows Git Credential Manager via interop (appendWindowsPath=false, so use full path)
 [credential]
   helper = /mnt/c/Program\\ Files/Git/mingw64/bin/git-credential-manager.exe
+  azreposCredentialType = oauth
 [credential "https://dev.azure.com"]
   useHttpPath = true
 # Sign commits ONLY in Azure DevOps repos (1Password SSH key via Windows signer).
@@ -192,6 +201,7 @@
 [credential]
 	helper =
 	helper = manager
+	azreposCredentialType = oauth
 [credential "https://dev.azure.com"]
 	useHttpPath = true
 {{- end }}

--- a/home/dot_config/git/config.tmpl
+++ b/home/dot_config/git/config.tmpl
@@ -180,6 +180,16 @@
 # live in the shared dev.azure.com block above.
 [credential]
 	helper = /mnt/c/Program\\ Files/Git/mingw64/bin/git-credential-manager.exe
+# Azure-scoped headless fallback. When GCM returns no cached token and cannot
+# show its Windows sign-in dialog (e.g. headless ssh-from-mac with an expired
+# token), git falls through to this az-CLI mint helper, which mints a fresh AAD
+# token non-interactively from the cached `az` session. Listed AFTER the GCM
+# helper above so GCM stays primary — git uses the first helper that returns
+# credentials. NO `helper =` reset here: a reset would wipe GCM from the Azure
+# chain (the bug that forced az-only auth before its 2026-06-15 retirement).
+# Script is managed at ~/.git-azdo-helper.sh (work-WSL only; see .chezmoiignore).
+[credential "https://dev.azure.com"]
+	helper = {{ .chezmoi.homeDir }}/.git-azdo-helper.sh
 # Sign commits ONLY in Azure DevOps repos (1Password SSH key via Windows signer).
 # Other repos stay unsigned. Matched on the repo's remote URL (git 2.36+).
 [includeIf "hasconfig:remote.*.url:https://dev.azure.com/**"]

--- a/home/dot_config/git/config.tmpl
+++ b/home/dot_config/git/config.tmpl
@@ -142,17 +142,25 @@
 [credential "https://gist.github.com"]
 	helper = !"{{ $ghPath }}" auth git-credential
 {{- end }}
+{{- /* Azure DevOps applies on: macOS (work-on-personal), native Windows, and
+       work WSL. NOT personal WSL (azure is work-only there). */ -}}
+{{- $azure := or (eq .chezmoi.os "darwin") (and (eq .chezmoi.os "windows") (not .is_wsl)) (and .work .is_wsl) }}
+{{ if $azure -}}
+# Azure DevOps (all platforms that use it): GCM via Microsoft OAuth. useHttpPath
+# scopes tokens per-org. The helper itself is set per-platform below — on macOS
+# the general helper is osxkeychain, so `manager` is scoped to azure here; on
+# Windows/WSL a global GCM helper is set that azure inherits.
+[credential "https://dev.azure.com"]
+	useHttpPath = true
+	azreposCredentialType = oauth
+{{- if eq .chezmoi.os "darwin" }}
+	helper =
+	helper = manager
+{{- end }}
+{{- end }}
 {{ if eq .chezmoi.os "darwin" -}}
 [credential]
 	helper = osxkeychain
-	azreposCredentialType = oauth
-# Azure DevOps on macOS: Git Credential Manager (Microsoft OAuth, token cached
-# in osxkeychain), consistent with the GCM setup on Windows/WSL. Empty `helper =`
-# resets the chain so osxkeychain doesn't also fire for dev.azure.com.
-[credential "https://dev.azure.com"]
-	helper =
-	helper = manager
-	useHttpPath = true
 {{- end }}
 {{- if .personal }}
 [gpg]
@@ -167,36 +175,30 @@
 # Route git SSH transport through Windows ssh.exe so it uses the 1Password
 # SSH agent on the Windows host (interop). Full path: appendWindowsPath=false.
 [core]
-  sshCommand = /mnt/c/Windows/System32/OpenSSH/ssh.exe
-# Windows Git Credential Manager via interop (appendWindowsPath=false, so use full path)
+	sshCommand = /mnt/c/Windows/System32/OpenSSH/ssh.exe
+# Windows Git Credential Manager via interop (full path). Azure-specific settings
+# live in the shared dev.azure.com block above.
 [credential]
-  helper = /mnt/c/Program\\ Files/Git/mingw64/bin/git-credential-manager.exe
-  azreposCredentialType = oauth
-[credential "https://dev.azure.com"]
-  useHttpPath = true
+	helper = /mnt/c/Program\\ Files/Git/mingw64/bin/git-credential-manager.exe
 # Sign commits ONLY in Azure DevOps repos (1Password SSH key via Windows signer).
 # Other repos stay unsigned. Matched on the repo's remote URL (git 2.36+).
 [includeIf "hasconfig:remote.*.url:https://dev.azure.com/**"]
-  path = ~/.config/git/azure-signing.inc
+	path = ~/.config/git/azure-signing.inc
 [includeIf "hasconfig:remote.*.url:git@ssh.dev.azure.com:**"]
-  path = ~/.config/git/azure-signing.inc
+	path = ~/.config/git/azure-signing.inc
 {{- end }}
 
 {{- if and (eq .chezmoi.os "windows") (not .is_wsl) }}
-# Native Windows Git Credential Manager.
-# Git-for-Windows sets `credential.helper = manager` in system config, so
-# without the empty `helper =` reset we'd chain system + user entries and
-# call GCM twice per request. `manager` is the GfW-provided alias for GCM —
-# avoids hardcoding C:/Program Files/Git/mingw64/bin/git-credential-manager.exe
-# and survives GCM being installed via scoop or moved by a GfW update.
-# Needed for non-github https remotes (Azure DevOps etc.); github.com is
-# already covered by the gh-CLI block above.
+# Native Windows Git Credential Manager. Git-for-Windows sets
+# `credential.helper = manager` in system config, so the empty `helper =` reset
+# prevents chaining system + user entries (double GCM call per request).
+# `manager` is the GfW alias for GCM — avoids hardcoding the full GCM path and
+# survives GCM moving (scoop / GfW update). Covers non-github https remotes;
+# github.com is handled by the gh-CLI block above. Azure-specific settings live
+# in the shared dev.azure.com block above.
 [credential]
 	helper =
 	helper = manager
-	azreposCredentialType = oauth
-[credential "https://dev.azure.com"]
-	useHttpPath = true
 {{- end }}
 
 {{- if lookPath "delta" }}

--- a/home/dot_config/git/config.tmpl
+++ b/home/dot_config/git/config.tmpl
@@ -19,16 +19,16 @@
 	cm = commit --message
 	co = checkout
 	cob = checkout -b
-	com = checkout master
+	com = checkout main
 	cp = cherry-pick
 	csm = commit -S --message
 	d = diff --patience
 	dc = diff --cached
-	dom = diff origin/master
+	dom = diff origin/main
 	fo = fetch origin
 	fu = "!git log -n 16 --pretty=format:'%h %s' --no-merges | fzf | cut -c -7 | xargs -o git commit --fixup"
 	g = grep --line-number
-	mbhom = merge-base HEAD origin/master
+	mbhom = merge-base HEAD origin/main
 	mff = merge --ff-only
 	ol = log --pretty=oneline
 	l = log --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit
@@ -40,20 +40,13 @@
 	rc = rebase --continue
 	ri = rebase --interactive
 	rl = reflog
-	riom = rebase --interactive origin/master
+	riom = rebase --interactive origin/main
 	rpo = remote prune origin
 	s = status -sb
 	sh = "!git log -n 16 --pretty=format:'%h %s' --no-merges | fzf | cut -c -7 | xargs -o git show"
 	ss = "commit --message 'chore: snapshot' --no-gpg-sign"
 	su = submodule update
 	wd = diff --patience --word-diff
-	# https://golang.org/doc/contribute.html
-	change = codereview change
-	gofmt = codereview gofmt
-	mail = codereview mail
-	pending = codereview pending
-	submit = codereview submit
-	sync = codereview sync
 [branch]
 	sort = -committerdate
 [color]
@@ -128,7 +121,7 @@
 [transfer]
 	fsckobjects = true
 [trim]
-	bases = master,gh-pages
+	bases = main,gh-pages
 
 {{- if .personal }}
 [url "git@github.com:Drewtopia/"]

--- a/home/dot_config/shell/private_015-vault.sh.tmpl
+++ b/home/dot_config/shell/private_015-vault.sh.tmpl
@@ -1,0 +1,10 @@
+# 015-vault.sh — credentials rendered from 1Password at `chezmoi apply` (mode 0600).
+# Pulled at build time, not runtime — shell startup needs no op session.
+{{ if not .ephemeral -}}
+export GITHUB_TOKEN={{ onepasswordRead (printf "op://%s/GitHub PAT/token" .opVault) | trim }}
+{{ end -}}
+{{ if and (not .ephemeral) (not .work) -}}
+export GEMINI_API_KEY={{ onepasswordRead "op://Private/Gemini API Key/token" | trim }}
+{{ else if .work -}}
+export GEMINI_API_KEY={{ onepasswordRead "op://Employee/Gemini API Key/password" | trim }}
+{{ end -}}

--- a/home/dot_config/television/cable/readmes.toml.tmpl
+++ b/home/dot_config/television/cable/readmes.toml.tmpl
@@ -1,0 +1,32 @@
+[metadata]
+name = "readmes"
+description = "Read README docs in the dotfiles repo (rendered with glow)"
+requirements = ["fd", "glow", "chezmoi"]
+
+# Source = the chezmoi git working tree (parent of `chezmoi source-path`, which
+# points at .../chezmoi/home). The root README.md is repo-only — never applied
+# to $HOME — so we must list from the repo, not from ~. fd respects .gitignore,
+# so vendored/external READMEs (oh-my-zsh, p10k, tpm) are excluded automatically.
+[source]
+{{ if eq .chezmoi.os "windows" -}}
+command = "fd -g 'README*' (Split-Path (chezmoi source-path))"
+{{ else -}}
+command = '''fd -g 'README*' "$(dirname "$(chezmoi source-path)")"'''
+{{ end -}}
+
+[preview]
+command = "glow -s dark '{}'"
+
+[keybindings]
+enter = "actions:read"
+ctrl-e = "actions:edit"
+
+[actions.read]
+description = "Read the rendered README in glow's pager"
+command = "glow -p '{}'"
+mode = "execute"
+
+[actions.edit]
+description = "Open the source file in the editor"
+command = "${EDITOR:-nvim} '{}'"
+mode = "execute"

--- a/home/dot_zshenv.tmpl
+++ b/home/dot_zshenv.tmpl
@@ -18,6 +18,15 @@ path=("$HOME/.local/bin" ${path:#$HOME/.local/bin})
 path=("/opt/homebrew/bin" ${path:#/opt/homebrew/bin})
 {{- end }}
 
+# mise shims — on PATH for ALL shells, including non-interactive ones
+# (topgrade, cron, `zsh -c`) that never source .zshrc. Interactive shells
+# additionally run `mise activate` in shell/010-mise.sh; typeset -U above
+# dedupes the overlap. Without this, mise tools are "command not found" in
+# any non-interactive context.
+{{- if .dev_computer }}
+path=("{{ .directories.mise_dir }}/shims" ${path:#{{ .directories.mise_dir }}/shims})
+{{- end }}
+
 # XDG-aware application configurations
 alias wget="wget --hsts-file='${XDG_DATA_HOME}/wget-hsts'"
 export ANDROID_HOME="$XDG_DATA_HOME/android"

--- a/home/dot_zshrc.tmpl
+++ b/home/dot_zshrc.tmpl
@@ -132,14 +132,6 @@ export EDITOR=nvim
 {{ else -}}
 export EDITOR=vim
 {{ end -}}
-{{- if not .ephemeral }}
-export GITHUB_TOKEN={{ onepasswordRead (printf "op://%s/GitHub PAT/token" .opVault) | trim }}
-{{- end }}
-{{- if and (not .ephemeral) (not .work) }}
-export GEMINI_API_KEY={{ onepasswordRead "op://Private/Gemini API Key/token" | trim }}
-{{- else if .work }}
-export GEMINI_API_KEY={{ onepasswordRead "op://Employee/Gemini API Key/password" | trim }}
-{{- end }}
 # MANPATH is managed via array syntax and typeset -aU
 export LANG=en_US.UTF-8
 export LC_ALL=en_US.UTF-8

--- a/home/executable_dot_git-azdo-helper.sh
+++ b/home/executable_dot_git-azdo-helper.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Git credential helper: mint an Azure DevOps access token from the cached `az`
+# CLI session. Serves as the HEADLESS FALLBACK in the WSL2 Azure credential
+# chain — the primary is the Windows Git Credential Manager (.exe via interop).
+# git falls through to this only when GCM returns no cached token and cannot
+# show its Windows sign-in dialog (e.g. a headless ssh-from-mac session with an
+# expired token). Minting is non-interactive, so it works without a desktop.
+#
+# The --resource GUID is the public Azure DevOps first-party app ID, not a
+# secret. Managed by chezmoi but deployed only on work WSL2 (gated in
+# .chezmoiignore.tmpl); wired into the chain by dot_config/git/config.tmpl.
+if [ "$1" = "get" ]; then
+  echo "username=azuredevops"
+  echo "password=$(az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --query accessToken -o tsv)"
+fi


### PR DESCRIPTION
Mixed dotfiles branch. Main themes:

## Azure DevOps git credential architecture
- Adopt Git Credential Manager for Azure DevOps on macOS (osxkeychain, Microsoft OAuth), retiring the bespoke az-CLI mint helper there.
- Dedupe the shared `dev.azure.com` settings (`useHttpPath`, `azreposCredentialType`) into one block across platforms.
- **WSL2: GCM primary + az-CLI mint fallback (chained).** GCM serves the cached AAD token from Windows Credential Manager headlessly; on expiry (e.g. headless `ssh work-wsl` from the Mac, where GCM can't show its sign-in dialog), git falls through to `~/.git-azdo-helper.sh`, which mints a fresh token non-interactively from the `az` session. The mint script is now chezmoi-managed and gated to work+WSL.
- **Footgun documented:** never `helper =` (empty reset) before the fallback — it wipes the inherited global GCM from the Azure chain. The fallback is appended *after* the global GCM line (file order = chain order).
- Merge the two `.personal`-gated blocks into one.
- Update `docs/github-auth-architecture.md` with the verified WSL2 chain.

## Shell
- Put mise shims on PATH in `.zshenv` for non-interactive shells.
- Extract credential exports to a private vault module.

## Television
- Add the `readmes` cable channel.

Verified on work-WSL: push authenticates via GCM (primary), az-mint present as fallback, rc=0.