### PR TITLE
Feat/conventional branch hook

### DIFF
--- a/home/.chezmoidata/skills.yaml
+++ b/home/.chezmoidata/skills.yaml
@@ -39,6 +39,11 @@ skill_repos:
     skills:
       - conventional-commit
       - playwright-generate-test
+  - repo: conventional-branch/conventional-branch
+    # Teaches valid Conventional Branch names; pairs with commit-check
+    # enforcement in dot_claude/hooks/bash-checks/gate-push-convention.js.
+    skills:
+      - conventional-branch
   - repo: pproenca/dot-skills
     # 154-skill personal collection; pull only what we use.
     skills:

--- a/home/dot_claude/hooks/bash-checks/gate-push-convention.js
+++ b/home/dot_claude/hooks/bash-checks/gate-push-convention.js
@@ -1,79 +1,122 @@
 'use strict';
 /**
- * PreToolUse(Bash) check: gate `git push` on conventional-commit branch naming.
- * Port of gate-git-push-convention.sh.
+ * PreToolUse(Bash) check: gate `git push` on Conventional Branch naming via
+ * commit-check (https://github.com/commit-check/commit-check) — the policy
+ * engine, not a homegrown regex. Validates the CURRENT branch name against the
+ * Conventional Branch 1.0.0 spec (commit-check's default config).
  *
- * Defers (allows) on force-push and protected-branch push — those are handled
- * by block-dangerous-git. Otherwise the pushed branch must match
- *   <prefix>(<scope>)?!?/<slug>
- * else block with a rename suggestion.
+ * Scope: naming only. Force-push (any branch) and protected-branch pushes are
+ * already blocked by block-dangerous-git, which runs earlier in the dispatcher.
  *
- * run(input) -> { exitCode: 0 } | { exitCode: 2, stderr }
+ * Availability: commit-check is installed via mise (pipx:commit-check). If it
+ * can't be located, this check degrades to "allow" — matching the harness
+ * convention in lib/git.js (allow when the tool is absent) rather than blocking
+ * every push on a half-provisioned machine. Prevention still comes from the
+ * conventional-branch skill; force/protected safety from block-dangerous-git.
+ *
+ * Note: commit-check --branch validates the CURRENT branch, so an explicit
+ * cross-branch refspec (`git push origin other` while on a different branch)
+ * is not separately validated — pushes are virtually always the current branch.
+ *
+ * run(input, deps?) -> { exitCode: 0 } | { exitCode: 2, stderr }
+ *   deps lets tests inject { check, repoRoot, currentBranch } deterministically.
  */
 
+const { execFileSync } = require('node:child_process');
 const { getCommand } = require('../lib/hook-io');
 const { currentBranch, repoRoot } = require('../lib/git');
 
-const PROTECTED = 'main|master|develop';
-const CONV =
-    '(feat|fix|chore|refactor|docs|test|perf|ci|build|style|revert)(\\([a-z0-9_-]+\\))?!?/[A-Za-z0-9._/-]+';
+const isGitPush = cmd =>
+    /(^|[^a-zA-Z])git(\s+-c\s+\S+)*\s+push(\s|$)/.test(cmd);
 
-function run(input) {
-    const cmd = getCommand(input);
-    if (!cmd) return { exitCode: 0 };
+/**
+ * Run `commit-check --branch` in `cwd`, preferring it on PATH and falling back
+ * to mise. Returns:
+ *   { ok: true }              branch passes
+ *   { ok: false, output }     branch fails (commit-check non-zero exit)
+ *   { unavailable: true }     commit-check could not be located/run
+ */
+// Strip mise's own diagnostics so only commit-check's verdict reaches the user.
+const stripMiseNoise = s =>
+    String(s || '')
+        .split('\n')
+        .filter(line => !/^mise (WARN|ERROR)/.test(line))
+        .join('\n')
+        .trim();
 
-    // Only act on `git push` (allowing `-c key=val` between git and push).
-    if (!/(^|[^a-zA-Z])git( -c [^ ]+)* push( |$)/.test(cmd))
-        return { exitCode: 0 };
+function checkBranch(cwd) {
+    const flags = ['--branch', '--no-banner'];
+    const opts = { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] };
+    // After `chezmoi apply` + `mise install`, commit-check is activated and the
+    // bare shim works (fast) — so it is the primary runner. `mise x` resolves
+    // the tool even when it is installed-but-not-yet-activated (the bare shim
+    // then errors "No version is set"), so it is the fallback for that window.
+    const invocations = [
+        ['commit-check', flags],
+        ['mise', ['x', 'pipx:commit-check@latest', '--', 'commit-check', ...flags]],
+    ];
 
-    // Defer to stricter hooks for force-push and protected-branch push.
-    if (/push.*(--force([^-]|$)|--force-with-lease|\s-f(\s|$))/.test(cmd))
-        return { exitCode: 0 };
-    if (new RegExp(`([\\s:/])(${PROTECTED})(\\s|$)`).test(cmd))
-        return { exitCode: 0 };
-
-    const branch = currentBranch();
-    if (branch && new RegExp(`^(${PROTECTED})$`).test(branch))
-        return { exitCode: 0 };
-
-    // Everything after `push` — bare vs argful.
-    const m = cmd.match(/git(?: -c [^ ]+)* push\s*(.*)/);
-    const pushTail = (m ? m[1] : '').replace(/\s*"$/, '');
-
-    if (pushTail === '') {
-        if (branch && new RegExp(`^${CONV}$`).test(branch))
-            return { exitCode: 0 };
-    } else if (new RegExp(`(^|[\\s:/])${CONV}(\\s|$)`).test(pushTail)) {
-        return { exitCode: 0 };
+    let unrun = false; // true if no runner ever produced a verdict
+    for (let i = 0; i < invocations.length; i++) {
+        const [bin, args] = invocations[i];
+        const haveFallback = i < invocations.length - 1;
+        try {
+            execFileSync(bin, args, opts);
+            return { ok: true };
+        } catch (err) {
+            if (err && err.code === 'ENOENT') {
+                unrun = true;
+                continue; // runner not found — try the next invocation
+            }
+            const raw = [err.stdout, err.stderr]
+                .map(s => String(s || ''))
+                .join('\n');
+            // A non-activated mise shim fails as a wrapper ("mise ERROR …"),
+            // not as a commit-check verdict — fall through to the next runner.
+            if (haveFallback && /mise ERROR/.test(raw)) {
+                unrun = true;
+                continue;
+            }
+            return { ok: false, output: stripMiseNoise(raw) };
+        }
     }
+    return { unavailable: unrun };
+}
 
-    // Non-conventional → block with rename suggestion.
-    const worktree = repoRoot() || '<unknown>';
-    const pushArgs = (cmd.match(/git(?: -c [^ ]+)* push (.*)/) || [, ''])[1];
-    const b = branch || '<unknown>';
+function run(input, deps = {}) {
+    const check = deps.check || checkBranch;
+    const getRepoRoot = deps.repoRoot || repoRoot;
+    const getBranch = deps.currentBranch || currentBranch;
 
+    const cmd = getCommand(input);
+    if (!cmd || !isGitPush(cmd)) return { exitCode: 0 };
+
+    const worktree = getRepoRoot();
+    if (!worktree) return { exitCode: 0 }; // not in a repo — nothing to gate
+
+    const result = check(worktree);
+    if (result.ok || result.unavailable) return { exitCode: 0 };
+
+    const branch = getBranch() || '<unknown>';
     return {
         exitCode: 2,
         stderr: [
-            `⚠️  Branch "${b}" does not match conventional-commit naming.`,
+            `⚠️  Branch "${branch}" fails Conventional Branch (commit-check).`,
             '',
-            'Expected shape: <prefix>(<scope>)?!?/<slug>',
-            '  prefixes: feat fix chore refactor docs test perf ci build style revert',
-            '  examples: chore/oxlint-fix',
-            '            feat(auth)/login-flow',
-            '            fix(api)/null-deref',
-            '            feat!/breaking-change',
+            result.output || '(no detail reported by commit-check)',
+            '',
+            'Conventional Branch 1.0.0 — https://conventionalbranch.org',
+            '  <type>/<description>',
+            '  types:    feature feat bugfix fix hotfix release chore',
+            '  rules:    lowercase a-z0-9 + hyphens; dots only in release/ versions;',
+            '            no underscores, uppercase, or leading/trailing/double -',
+            '  examples: feat/add-login-page   fix/header-bug   release/v1.2.0',
             '',
             'Either:',
-            '  • Rename the branch:',
-            '      git branch -m <new-conventional-name>',
-            '  • Or push yourself with the ! prefix (the ! runs it in your session):',
-            `      ! cd "${worktree}"; git push ${pushArgs}`,
-            '',
-            `Branch:   ${b}`,
-            `Worktree: ${worktree}`,
+            '  • Rename the branch:  git branch -m <new-conventional-name>',
+            `  • Or push yourself with the ! prefix:  ! cd "${worktree}"; git push ...`,
         ].join('\n'),
     };
 }
 
-module.exports = { run };
+module.exports = { run, isGitPush, checkBranch };

--- a/home/dot_claude/hooks/tests/gate-push-convention.test.js
+++ b/home/dot_claude/hooks/tests/gate-push-convention.test.js
@@ -1,35 +1,74 @@
 'use strict';
 /**
- * Port safety net for gate-push-convention.js — deterministic paths only.
- * (The bare-push block path depends on the live current branch, so it is
- * verified end-to-end from a non-repo cwd rather than here.)
+ * Unit tests for gate-push-convention.js. The branch decision is delegated to
+ * commit-check (a subprocess), so tests inject a fake `check` plus `repoRoot`
+ * and `currentBranch` to exercise the decision logic deterministically without
+ * spawning anything.
  */
 
 const { test } = require('node:test');
 const assert = require('node:assert');
-const { run } = require('../bash-checks/gate-push-convention');
+const { run, isGitPush } = require('../bash-checks/gate-push-convention');
 
-const code = cmd => run({ tool_input: { command: cmd } }).exitCode;
+const input = cmd => ({ tool_input: { command: cmd } });
+const deps = (over = {}) => ({
+    repoRoot: () => '/repo',
+    currentBranch: () => 'bad_branch',
+    check: () => ({ ok: true }),
+    ...over,
+});
 
-// Deferred or allowed regardless of current branch:
-const ALLOWED = [
-    'git status', // not a push
-    'npm test', // not git
-    'git push --force origin feat/x', // force -> defer to block-dangerous-git
-    'git push origin main', // protected -> defer
-    'git push origin develop', // protected -> defer
-    'git push origin feat/login', // conventional refspec present
-    'git push origin fix(api)/null-deref', // conventional w/ scope
-    'git push origin feat!/breaking', // conventional w/ breaking marker
-    'git push origin chore/oxlint-fix',
+// --- push detection -------------------------------------------------------
+const PUSHES = [
+    'git push',
+    'git push origin feat/x',
+    'git  push', // extra whitespace must not slip the gate
+    'git -c key=val push',
+    'FOO=bar git push',
 ];
+const NON_PUSHES = ['git status', 'npm test', 'git pushd', 'pushing'];
 
-for (const cmd of ALLOWED) {
-    test(`allows/defers: ${cmd}`, () => assert.equal(code(cmd), 0));
-}
+for (const c of PUSHES) test(`isGitPush true: ${c}`, () => assert.ok(isGitPush(c)));
+for (const c of NON_PUSHES)
+    test(`isGitPush false: ${c}`, () => assert.ok(!isGitPush(c)));
 
-// Argful push whose target is non-conventional and non-protected blocks,
-// independent of the current branch (the explicit target drives the decision).
-test('blocks argful push to non-conventional target', () => {
-    assert.equal(code('git push origin randombranch'), 2);
+// --- decision logic -------------------------------------------------------
+test('non-push command allowed without invoking commit-check', () => {
+    let called = false;
+    const d = deps({ check: () => ((called = true), { ok: false }) });
+    assert.equal(run(input('git status'), d).exitCode, 0);
+    assert.equal(called, false);
+});
+
+test('push outside a repo allowed without invoking commit-check', () => {
+    let called = false;
+    const d = deps({
+        repoRoot: () => '',
+        check: () => ((called = true), { ok: false }),
+    });
+    assert.equal(run(input('git push'), d).exitCode, 0);
+    assert.equal(called, false);
+});
+
+test('valid branch (commit-check ok) allowed', () => {
+    assert.equal(run(input('git push'), deps({ check: () => ({ ok: true }) })).exitCode, 0);
+});
+
+test('commit-check unavailable degrades to allow', () => {
+    assert.equal(
+        run(input('git push'), deps({ check: () => ({ unavailable: true }) })).exitCode,
+        0,
+    );
+});
+
+test('invalid branch (commit-check fail) blocks with detail + branch name', () => {
+    const d = deps({
+        currentBranch: () => 'bad_branch',
+        check: () => ({ ok: false, output: 'commit-check: branch name invalid' }),
+    });
+    const res = run(input('git push -u origin bad_branch'), d);
+    assert.equal(res.exitCode, 2);
+    assert.match(res.stderr, /bad_branch/);
+    assert.match(res.stderr, /commit-check: branch name invalid/);
+    assert.match(res.stderr, /conventionalbranch\.org/);
 });

--- a/home/dot_config/mise/config.toml.tmpl
+++ b/home/dot_config/mise/config.toml.tmpl
@@ -55,6 +55,11 @@ chezmoi = "latest"
 # npm-backed CLI tools (pure JS, cross-platform)
 "npm:defuddle" = "latest"
 
+# pipx-backed CLI tools (pure Python, cross-platform)
+# commit-check: policy engine for Conventional Commits + Conventional Branch +
+# push safety. Drives the git/Claude push gate (see dot_claude/hooks).
+"pipx:commit-check" = "latest"
+
 # Cross-platform shell tools
 "aqua:junegunn/fzf" = "latest"
 "aqua:ajeetdsouza/zoxide" = "latest"


### PR DESCRIPTION
…nch)

Replace the homegrown branch-name regex in gate-push-convention with a
call to commit-check — the policy engine for Conventional Commits and
Conventional Branch. The hook now validates the current branch against
the Conventional Branch 1.0.0 spec rather than a bespoke pattern.

- gate-push-convention.js: shell to commit-check (bare shim primary,
  `mise x` fallback for the installed-but-not-activated window); naming
  only, since force-push and protected pushes stay with
  block-dangerous-git; degrade-to-allow when commit-check is absent.
- tests: rewrite with dependency injection so the decision logic is
  unit-tested without spawning subprocesses; add push-detection cases.
- mise: track pipx:commit-check so it installs across machines.

Branch-name prevention is handled by the conventional-branch skill,
installed per machine via `npx skills add` (not chezmoi-tracked).