### PR TITLE
feat(hooks): global commit-check branch policy via --config

### DIFF
--- a/home/dot_claude/hooks/bash-checks/gate-push-convention.js
+++ b/home/dot_claude/hooks/bash-checks/gate-push-convention.js
@@ -18,16 +18,45 @@
  * cross-branch refspec (`git push origin other` while on a different branch)
  * is not separately validated — pushes are virtually always the current branch.
  *
+ * Policy: commit-check has no global config search path (it looks only in the
+ * repo + .github), so a repo-local cchk.toml wins when present, otherwise the
+ * gate points commit-check at the global ~/.config/commit-check/cchk.toml via
+ * --config. With neither, commit-check's strict defaults apply.
+ *
  * run(input, deps?) -> { exitCode: 0 } | { exitCode: 2, stderr }
  *   deps lets tests inject { check, repoRoot, currentBranch } deterministically.
  */
 
 const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 const { getCommand } = require('../lib/hook-io');
 const { currentBranch, repoRoot } = require('../lib/git');
 
 const isGitPush = cmd =>
     /(^|[^a-zA-Z])git(\s+-c\s+\S+)*\s+push(\s|$)/.test(cmd);
+
+const REPO_CONFIGS = [
+    'cchk.toml',
+    'commit-check.toml',
+    '.github/cchk.toml',
+    '.github/commit-check.toml',
+];
+const GLOBAL_CONFIG = path.join(os.homedir(), '.config', 'commit-check', 'cchk.toml');
+
+/**
+ * Resolve the `--config` flags for commit-check. A repo-local config wins (so a
+ * repo / its CI can own its policy); otherwise apply the global config if it
+ * exists; otherwise nothing (commit-check defaults). `opts` is injectable for tests.
+ */
+function configArgs(cwd, opts = {}) {
+    const exists = opts.exists || fs.existsSync;
+    const global = opts.global || GLOBAL_CONFIG;
+    if (REPO_CONFIGS.some(f => exists(path.join(cwd, f)))) return [];
+    if (exists(global)) return ['--config', global];
+    return [];
+}
 
 /**
  * Run `commit-check --branch` in `cwd`, preferring it on PATH and falling back
@@ -45,7 +74,7 @@ const stripMiseNoise = s =>
         .trim();
 
 function checkBranch(cwd) {
-    const flags = ['--branch', '--no-banner'];
+    const flags = ['--branch', '--no-banner', ...configArgs(cwd)];
     const opts = { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] };
     // After `chezmoi apply` + `mise install`, commit-check is activated and the
     // bare shim works (fast) — so it is the primary runner. `mise x` resolves
@@ -119,4 +148,4 @@ function run(input, deps = {}) {
     };
 }
 
-module.exports = { run, isGitPush, checkBranch };
+module.exports = { run, isGitPush, checkBranch, configArgs, GLOBAL_CONFIG };

--- a/home/dot_claude/hooks/tests/gate-push-convention.test.js
+++ b/home/dot_claude/hooks/tests/gate-push-convention.test.js
@@ -8,7 +8,11 @@
 
 const { test } = require('node:test');
 const assert = require('node:assert');
-const { run, isGitPush } = require('../bash-checks/gate-push-convention');
+const {
+    run,
+    isGitPush,
+    configArgs,
+} = require('../bash-checks/gate-push-convention');
 
 const input = cmd => ({ tool_input: { command: cmd } });
 const deps = (over = {}) => ({
@@ -31,6 +35,26 @@ const NON_PUSHES = ['git status', 'npm test', 'git pushd', 'pushing'];
 for (const c of PUSHES) test(`isGitPush true: ${c}`, () => assert.ok(isGitPush(c)));
 for (const c of NON_PUSHES)
     test(`isGitPush false: ${c}`, () => assert.ok(!isGitPush(c)));
+
+// --- config resolution ----------------------------------------------------
+test('repo-local config wins (no --config passed)', () => {
+    const exists = p => p === '/repo/cchk.toml';
+    assert.deepEqual(configArgs('/repo', { exists, global: '/g.toml' }), []);
+});
+test('no repo config + global present -> --config global', () => {
+    const exists = p => p === '/g.toml';
+    assert.deepEqual(configArgs('/repo', { exists, global: '/g.toml' }), [
+        '--config',
+        '/g.toml',
+    ]);
+});
+test('neither config present -> no flags (commit-check defaults)', () => {
+    assert.deepEqual(configArgs('/repo', { exists: () => false, global: '/g.toml' }), []);
+});
+test('.github/cchk.toml also counts as repo-local', () => {
+    const exists = p => p === '/repo/.github/cchk.toml';
+    assert.deepEqual(configArgs('/repo', { exists, global: '/g.toml' }), []);
+});
 
 // --- decision logic -------------------------------------------------------
 test('non-push command allowed without invoking commit-check', () => {

--- a/home/dot_config/commit-check/cchk.toml
+++ b/home/dot_config/commit-check/cchk.toml
@@ -1,0 +1,14 @@
+# Global commit-check policy. The push gate
+# (dot_claude/hooks/bash-checks/gate-push-convention.js) points commit-check at
+# this file via `--config` when a repo has no cchk.toml of its own; a repo-local
+# config always wins. https://commit-check.github.io
+[branch]
+# https://conventionalbranch.org, widened to the Conventional Commit type set
+# (+ wip) so everyday branches aren't rejected by the strict 7-type default.
+conventional_branch = true
+allow_branch_types = [
+  "feature", "feat", "bugfix", "fix", "hotfix", "release", "chore",
+  "refactor", "docs", "test", "perf", "ci", "style", "build", "revert", "wip",
+]
+# main/master/HEAD/PR-* are always allowed by default; add the other trunk-likes.
+allow_branch_names = ["develop", "staging"]


### PR DESCRIPTION
Widens commit-check's strict 7-type branch default (which blocked `refactor/`, `docs/`, `wip/`, `develop`).

- `dot_config/commit-check/cchk.toml`: global policy (Conventional Commit type set + wip; develop/staging standalone).
- `gate-push-convention.js`: repo-local cchk.toml wins, else `--config` global (commit-check has no global config search path).
- tests: configArgs resolution order. 18/18 unit + policy e2e pass (refactor/wip/docs/develop/staging pass; BadCaps/underscore blocked).