### PR TITLE
chore(brew): drop logi-options+ from cask auto-install

### DIFF
--- a/home/.chezmoiscripts/darwin/run_onchange_before_10-install-brew-packages.sh.tmpl
+++ b/home/.chezmoiscripts/darwin/run_onchange_before_10-install-brew-packages.sh.tmpl
@@ -19,6 +19,7 @@ set -eufo pipefail
     "tmux"
     "wget"
     "xz" -}}
+{{/* Excluded on purpose (do not auto-install): "logi-options+" — re-add to the list below to restore. */}}
 {{ $casks := list
 	"1password@nightly"
     "1password-cli"
@@ -51,7 +52,6 @@ set -eufo pipefail
     "keycastr"
     "keyclu"
     "leader-key"
-    "logi-options+"
     "lookaway"
     "lunar"
     "muzzle"


### PR DESCRIPTION
Remove logi-options+ from the darwin brew bundle so it is no longer installed on apply. Documented as an intentional exclusion above the cask list so it can be re-added easily.