### PR TITLE
chore: version packages (0.0.1)

### DIFF
--- a/.changeset/skills-reconcile-and-changesets.md
+++ b/.changeset/skills-reconcile-and-changesets.md
@@ -1,8 +1,0 @@
----
-"drewtopia-dotfiles": patch
----
-
-Reconcile mattpocock/skills to upstream v1.0.0 and adopt changesets.
-
-- Skills: replace `write-a-skill` → `writing-great-skills`, rename `diagnose` → `diagnosing-bugs`, drop `zoom-out`; add `codebase-design`, `domain-modeling`, `resolving-merge-conflicts`, `ask-matt`, `grilling`. Stale `~/.claude/skills` symlinks purged via `.chezmoiremove.tmpl`.
-- Tooling: adopt `@changesets/cli` for a versioned `CHANGELOG.md` (local-only, nothing published).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# drewtopia-dotfiles
+
+## 0.0.1
+
+### Patch Changes
+
+- [#21](https://github.com/Drewtopia/dotfiles/pull/21) [`658801d`](https://github.com/Drewtopia/dotfiles/commit/658801d683d206616f915fdf197f0630d95d7c42) Thanks [@Drewtopia](https://github.com/Drewtopia)! - Reconcile mattpocock/skills to upstream v1.0.0 and adopt changesets.
+
+  - Skills: replace `write-a-skill` → `writing-great-skills`, rename `diagnose` → `diagnosing-bugs`, drop `zoom-out`; add `codebase-design`, `domain-modeling`, `resolving-merge-conflicts`, `ask-matt`, `grilling`. Stale `~/.claude/skills` symlinks purged via `.chezmoiremove.tmpl`.
+  - Tooling: adopt `@changesets/cli` for a versioned `CHANGELOG.md` (local-only, nothing published).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drewtopia-dotfiles",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "private": true,
   "description": "Personal chezmoi-managed dotfiles. Changesets is used only for a versioned CHANGELOG — nothing is published to a registry.",
   "scripts": {


### PR DESCRIPTION
Generated by `changeset version` — consumes the skills-reconcile + changesets-adoption changeset into CHANGELOG.md and bumps to 0.0.1.