### PR TITLE
chore(skills): track 9 new mattpocock skills

### DIFF
--- a/home/.chezmoidata/skills.yaml
+++ b/home/.chezmoidata/skills.yaml
@@ -7,8 +7,7 @@
 # .chezmoiexternal.toml.tmpl, which went stale on upstream refactors.
 skill_repos:
   - repo: mattpocock/skills
-    # 21 skills: 5 productivity/, 14 engineering/, 2 misc/. Hidden-subdir
-    # skills (misc/, personal/, deprecated/, in-progress/) are excluded from
+    # Hidden-subdir skills (misc/, personal/, deprecated/, in-progress/) are excluded from
     # `npx skills add mattpocock/skills -l` BUT can still be installed by
     # name via the --skill flag, which the reconciler script uses.
     #
@@ -39,9 +38,19 @@ skill_repos:
       - to-issues
       - to-prd
       - triage
+      - code-review
+      - research
       # misc/ (hidden but installable by name)
       - git-guardrails-claude-code
       - migrate-to-shoehorn
+      - scaffold-exercises
+      # in-progress/ (unstable upstream; may rename/break — installable by name)
+      - wizard
+      - loop-me
+      - wayfinder
+      - writing-fragments
+      - writing-beats
+      - writing-shape
   - repo: vercel-labs/skills
     skills:
       - find-skills


### PR DESCRIPTION
Reconciles `home/.chezmoidata/skills.yaml` against upstream `mattpocock/skills`.

## Added
- **engineering/**: `code-review`, `research`
- **misc/**: `scaffold-exercises`
- **in-progress/** (unstable upstream; installable by name via `--skill`): `wizard`, `loop-me`, `wayfinder`, `writing-fragments`, `writing-beats`, `writing-shape`

## Also
- Drop the stale skill-count comment that went out of date on every reconcile.

Held back: `claude-handoff` (in-progress, overlaps existing `handoff`) and `setup-pre-commit` (JS/Husky-specific). All added skills install-verified on disk.