### PR TITLE
chore(skills): track mattpocock claude-handoff skill

### DIFF
--- a/home/.chezmoidata/skills.yaml
+++ b/home/.chezmoidata/skills.yaml
@@ -51,6 +51,7 @@ skill_repos:
       - writing-fragments
       - writing-beats
       - writing-shape
+      - claude-handoff
   - repo: vercel-labs/skills
     skills:
       - find-skills


### PR DESCRIPTION
Adds claude-handoff (in-progress/) to home/.chezmoidata/skills.yaml.

Active variant of the tracked handoff: instead of saving a handoff doc to disk, it launches a fresh background agent seeded with the summary (claude --bg --name NAME SUMMARY), started in cwd and managed via claude agents.

Rationale: periodic agent-driven review/update sessions. Claude-Code-specific and in-progress upstream (may rename/break). Install-verified on disk.