### PR TITLE
chore(skills): track microsoftdocs azure-repos skill

### DIFF
--- a/home/.chezmoidata/skills.yaml
+++ b/home/.chezmoidata/skills.yaml
@@ -78,3 +78,7 @@ skill_repos:
   - repo: blader/humanizer
     skills:
       - humanizer
+  - repo: microsoftdocs/agent-skills
+    # Azure Repos expert skill; replaces the lost project-vendored azure-repos.
+    skills:
+      - azure-repos


### PR DESCRIPTION
Adds `microsoftdocs/agent-skills` -> `azure-repos` to skills.yaml; replaces the lost project-vendored azure-repos skill.

Authored on work-wsl; cut from current main, coexists with today's mattpocock additions.