### PR TITLE
chore(shell): add kanata launchctl control functions

### DIFF
--- a/home/dot_config/shell/055-kanata.sh.tmpl
+++ b/home/dot_config/shell/055-kanata.sh.tmpl
@@ -1,0 +1,9 @@
+####################### KANATA #######################
+{{- if and (eq .chezmoi.os "darwin") (lookPath "kanata") }}
+# Kanata runs as system LaunchDaemon com.chezmoi.kanata (sudo required)
+kanata-start()   { sudo launchctl bootstrap system /Library/LaunchDaemons/com.chezmoi.kanata.plist; }
+kanata-stop()    { sudo launchctl bootout system/com.chezmoi.kanata; }
+kanata-restart() { sudo launchctl kickstart -k system/com.chezmoi.kanata; }   # reload after .kbd edit
+kanata-status()  { sudo launchctl list com.chezmoi.kanata; }
+kanata-logs()    { tail -f /tmp/kanata.log; }
+{{- end }}


### PR DESCRIPTION
## What

Adds `home/dot_config/shell/055-kanata.sh.tmpl` with five helper functions for controlling the Kanata keyboard remapper on macOS:

| function | action |
|---|---|
| `kanata-start` | bootstrap the `com.chezmoi.kanata` LaunchDaemon |
| `kanata-stop` | bootout the daemon |
| `kanata-restart` | `kickstart -k` — reload after editing a `.kbd` config |
| `kanata-status` | list the service |
| `kanata-logs` | tail `/tmp/kanata.log` |

## Why

Kanata runs as a system LaunchDaemon (`com.chezmoi.kanata`), so starting/stopping previously meant typing full `sudo launchctl ...` invocations by hand. These wrappers give short, memorable names.

## Notes

- Guarded by `{{ if and (eq .chezmoi.os "darwin") (lookPath "kanata") }}` — renders empty on non-macOS or machines without kanata installed.
- Own file rather than appended to `050-common-aliases.sh.tmpl`, matching the dir's one-file-per-concern convention (`025-tmux`, `030-system-tools`, etc.). The shell loader globs `*.sh` numerically, so `055` loads right after aliases.