### PR TITLE
chore(skills): reconcile mattpocock set to v1.1.0

### DIFF
--- a/home/.chezmoidata/skills.yaml
+++ b/home/.chezmoidata/skills.yaml
@@ -15,6 +15,10 @@ skill_repos:
     #   write-a-skill → writing-great-skills (replaced)
     #   diagnose      → diagnosing-bugs (renamed)
     #   zoom-out      → removed upstream, no replacement
+    #
+    # Reconciled against upstream v1.1.0 (Jul 2026):
+    #   to-issues, to-prd → unified upstream into to-spec + to-tickets
+    #   wayfinder         → graduated in-progress/ to engineering/ (now stable)
     # Stale on-disk dirs purged via .chezmoiremove.tmpl.
     skills:
       # productivity/
@@ -35,11 +39,12 @@ skill_repos:
       - implement
       - setup-matt-pocock-skills
       - tdd
-      - to-issues
-      - to-prd
+      - to-spec
+      - to-tickets
       - triage
       - code-review
       - research
+      - wayfinder
       # misc/ (hidden but installable by name)
       - git-guardrails-claude-code
       - migrate-to-shoehorn
@@ -47,7 +52,6 @@ skill_repos:
       # in-progress/ (unstable upstream; may rename/break — installable by name)
       - wizard
       - loop-me
-      - wayfinder
       - writing-fragments
       - writing-beats
       - writing-shape

--- a/home/.chezmoiremove.tmpl
+++ b/home/.chezmoiremove.tmpl
@@ -57,3 +57,10 @@
 .agents/skills/write-a-skill
 .agents/skills/diagnose
 .agents/skills/zoom-out
+
+# mattpocock/skills v1.1.0 (Jul 2026): to-issues + to-prd unified upstream
+# into to-spec + to-tickets. Same dual-path removal as above.
+.claude/skills/to-issues
+.claude/skills/to-prd
+.agents/skills/to-issues
+.agents/skills/to-prd


### PR DESCRIPTION
Upstream cut v1.1.0 with two structural changes.

## Replaced
`to-issues` + `to-prd` were unified upstream into `to-spec` + `to-tickets` (commit: "refactor: unify planning skills into /to-spec + /to-tickets").

## Graduated
`wayfinder` moved `in-progress/` -> `engineering/` (commit: "Graduate wayfinder to engineering"). Same skill name, so no install change — but it's stable now, so it moves out of the unstable in-progress block.

## Cleanup
`.chezmoiremove.tmpl` gains dual-path removals for the retired `to-issues`/`to-prd` — both the `.claude/skills` symlink and the unmanaged `.agents/skills` payload, which chezmoi doesn't track and would otherwise orphan on every machine.

All three new/moved skills install-verified on disk.