### PR TITLE
feat(hooks): warn when reading derived artifacts

### DIFF
--- a/home/dot_claude/hooks/tests/warn-derived-artifact.test.js
+++ b/home/dot_claude/hooks/tests/warn-derived-artifact.test.js
@@ -1,0 +1,58 @@
+'use strict';
+/** Safety net for warn-derived-artifact.js — pure noticeFor()/extractFilePath(). */
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const {
+    noticeFor,
+    isDerived,
+    extractFilePath,
+} = require('../warn-derived-artifact');
+
+// Summaries of other things: reading them warrants a re-verify nudge.
+const DERIVED = [
+    '/Users/drew/proj/MEMORY.md',
+    '/Users/drew/proj/memory.md',
+    '/Users/drew/proj/SESSION_LOG.md',
+    '/Users/drew/proj/handoff.md',
+    '/Users/drew/proj/handoff-2026-07-09.md',
+    '/Users/drew/proj/plans/refactor.md',
+    '/Users/drew/.claude/memory/tools/chezmoi.md',
+    'C:\\Users\\drew\\proj\\plans\\refactor.md',
+];
+for (const p of DERIVED) {
+    test(`derived: ${p}`, () => {
+        assert.ok(isDerived(p));
+        assert.match(noticeFor(p), /claim, not a canonical source/);
+    });
+}
+
+// Canonical sources and instruction files: silent. Firing here is pure noise.
+const CANONICAL = [
+    '/Users/drew/.claude/rules/verify-dont-trust.md',
+    '/Users/drew/.claude/skills/foo/SKILL.md',
+    '/Users/drew/proj/CLAUDE.md',
+    '/Users/drew/proj/README.md',
+    '/Users/drew/proj/src/index.js',
+    '/Users/drew/proj/docs/plans-old/x.md',
+    '/Users/drew/proj/plans/notes.txt',
+    '',
+    undefined,
+];
+for (const p of CANONICAL) {
+    test(`canonical: ${JSON.stringify(p)}`, () => {
+        assert.equal(isDerived(p), false);
+        assert.equal(noticeFor(p), '');
+    });
+}
+
+// Path extraction mirrors post-edit-format: file_path, then path, then ''.
+test('extractFilePath prefers file_path', () =>
+    assert.equal(
+        extractFilePath({ tool_input: { file_path: '/a.md', path: '/b.md' } }),
+        '/a.md',
+    ));
+test('extractFilePath falls back to path', () =>
+    assert.equal(extractFilePath({ tool_input: { path: '/b.md' } }), '/b.md'));
+test('extractFilePath tolerates missing tool_input', () =>
+    assert.equal(extractFilePath({}), ''));

--- a/home/dot_claude/hooks/warn-derived-artifact.js
+++ b/home/dot_claude/hooks/warn-derived-artifact.js
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+'use strict';
+/**
+ * PostToolUse(Read): when a derived artifact is read — a summary, handoff note,
+ * plan, or memory file — remind the model that the file is a claim, not a
+ * canonical source. Enforces the "verify, don't trust" rule at the moment of
+ * contact with the stale document.
+ *
+ * Injects via hookSpecificOutput.additionalContext (reaches the model's
+ * context); systemMessage would only reach the user, who is not the one about
+ * to cite the file. Never blocks — always exits 0.
+ *
+ * Toggle: HOOKS_DISABLED=post:read:derived-artifact
+ */
+
+const { readStdin, parseInput } = require('./lib/hook-io');
+const { isHookEnabled } = require('./lib/hook-flags');
+
+const HOOK_ID = 'post:read:derived-artifact';
+
+/** Files whose name alone marks them as a summary of something else. */
+const DERIVED_BASENAME = /^(memory|session_log|handoff[\w-]*)\.md$/i;
+
+/** Directories whose .md contents are summaries: plans/ and the memory store. */
+const DERIVED_DIR = /\/(plans|\.claude\/memory)\/.+\.md$/i;
+
+const NOTICE = [
+    'Derived artifact — this file is a claim, not a canonical source.',
+    'It was written against a branch, commit, and set of files that may have moved since.',
+    'Before citing or acting on anything in it: re-read the files it names, re-fetch the URLs it cites, and confirm they still match.',
+    'State "verified against X", or flag the claim as unverified.',
+].join(' ');
+
+function isDerived(filePath) {
+    if (!filePath) return false;
+    const normalized = String(filePath).replace(/\\/g, '/');
+    const basename = normalized.slice(normalized.lastIndexOf('/') + 1);
+    return DERIVED_BASENAME.test(basename) || DERIVED_DIR.test(normalized);
+}
+
+/** Pure: the context to inject for a read path, or '' when none is warranted. */
+function noticeFor(filePath) {
+    return isDerived(filePath) ? NOTICE : '';
+}
+
+function extractFilePath(input) {
+    const ti = (input && input.tool_input) || {};
+    return ti.file_path || ti.path || '';
+}
+
+async function main() {
+    const raw = await readStdin();
+    if (!isHookEnabled(HOOK_ID)) {
+        process.stdout.write(raw);
+        process.exit(0);
+    }
+    let notice = '';
+    try {
+        notice = noticeFor(extractFilePath(parseInput(raw)));
+    } catch {
+        notice = '';
+    }
+    if (notice) {
+        process.stdout.write(
+            JSON.stringify({
+                hookSpecificOutput: {
+                    hookEventName: 'PostToolUse',
+                    additionalContext: notice,
+                },
+            }),
+        );
+    } else {
+        process.stdout.write(raw);
+    }
+    process.exit(0);
+}
+
+if (require.main === module) main();
+
+module.exports = {
+    noticeFor,
+    isDerived,
+    extractFilePath,
+    NOTICE,
+    HOOK_ID,
+    DERIVED_BASENAME,
+    DERIVED_DIR,
+};

--- a/home/dot_claude/modify_settings.json.tmpl
+++ b/home/dot_claude/modify_settings.json.tmpl
@@ -131,6 +131,15 @@ managed=$(cat <<'CHEZMOI_SETTINGS_EOF'
             "command": "bash -c 'node \"${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/post-edit-format.js\"'"
           }
         ]
+      },
+      {
+        "matcher": "Read",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'node \"${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/warn-derived-artifact.js\"'"
+          }
+        ]
       }
     ],
     "Stop": [


### PR DESCRIPTION
## Why

Reading a summary, plan, or memory file gives no signal that it has drifted from the source it describes. The document reads as authoritative long after the branch, commit, or files it cites have moved. Stale `whatever.md` becomes stale analysis.

Pairs with the `verify-dont-trust` rule in the vault repo, which states the behaviour; this hook enforces a nudge at the moment of contact.

## What

`PostToolUse(Read)` hook matching derived artifacts:

- basename: `MEMORY.md`, `memory.md`, `SESSION_LOG.md`, `handoff*.md`
- directory: anything `.md` under `plans/` or `.claude/memory/`

On a match it injects a reminder that the file is a claim to be verified, not a canonical source.

## Notes

- Emits `hookSpecificOutput.additionalContext`, not `systemMessage` — only `additionalContext` reaches the model, and the model is what needs the reminder. Verified against the current hooks reference.
- Warn-only. Never blocks, always exits 0, passes stdin through untouched on no-match.
- Toggle: `HOOKS_DISABLED=post:read:derived-artifact`
- Follows the existing `warn-edit-on-protected.js` shape — pure predicate (`noticeFor`) split from `main()` so tests import it without spawning a process.

## Verification

- 20/20 unit tests pass (`node --test home/dot_claude/hooks/tests/warn-derived-artifact.test.js`)
- Exercised live against the running harness, not just unit tests:

| Read target | Branch under test | Result |
|---|---|---|
| `projects/.../memory/MEMORY.md` | basename regex | notice injected |
| `.claude-vault/rules/keep-comments.md` | negative control | silent |
| `.claude/memory/tools/chezmoi.md` | directory regex, nested | notice injected |

- Real stdin payload emits well-formed JSON; empty stdin exits 0 without hanging; disable toggle passes through.
- `modify_settings.json.tmpl` still renders parseable JSON; live `settings.json` shows `Read -> warn-derived-artifact.js` under `PostToolUse`.

Negative cases are covered so the hook stays quiet on canonical sources (`rules/`, `SKILL.md`, `CLAUDE.md`, `README.md`) rather than firing on every markdown read.

## Known limits

- Fires when the artifact is *read*, but the drift bites when the summary is *written* — by then the nudge may be far back in context. It is a nudge, not enforcement.
- A `src/memory.md` in an unrelated project would trip the basename rule. Cheap to narrow if it bites.