### PR TITLE
fix(cvault): refuse to commit through a failed autostash

### DIFF
--- a/home/dot_local/bin/executable_cvault
+++ b/home/dot_local/bin/executable_cvault
@@ -95,6 +95,21 @@ cmd_diff() {
 
 cmd_apply() {
     cd "$VAULT_DIR"
+    # Never `git add -A` over unmerged paths: it stages conflict markers as
+    # ordinary text and re-adds files an upstream commit deliberately deleted.
+    local conflicted
+    conflicted=$(conflicted_files)
+    if [ -n "$conflicted" ]; then
+        echo "✗ cvault: unresolved conflicts — refusing to commit." >&2
+        echo "$conflicted" | sed 's/^/    /' >&2
+        echo "  → resolve them, then re-run \`cvault apply\`" >&2
+        return 1
+    fi
+    if in_progress; then
+        echo "✗ cvault: rebase or merge in progress — refusing to commit." >&2
+        echo "  → run \`cvault merge\` to finish it first" >&2
+        return 1
+    fi
     if git diff --quiet && git diff --cached --quiet; then
         echo "cvault: no local changes to apply"
         return 0
@@ -107,15 +122,34 @@ cmd_apply() {
     echo "✓ Applied"
 }
 
+# Number of entries in the stash, 0 when empty.
+stash_count() {
+    git -C "$VAULT_DIR" stash list | wc -l | tr -d ' '
+}
+
 cmd_update() {
     cd "$VAULT_DIR"
     echo "→ Pulling..."
+    # `git pull --rebase --autostash` exits 0 even when the autostash fails to
+    # reapply — the conflict is reported as a warning. set -e will not catch
+    # it, so compare the stash depth across the pull instead.
+    local before after
+    before=$(stash_count)
     git pull --rebase --autostash
+    after=$(stash_count)
+    if [ "$after" -gt "$before" ]; then
+        echo "✗ cvault: autostash did not reapply — your changes are in stash@{0}." >&2
+        echo "  The working tree may hold conflict markers. Do NOT run \`cvault apply\`." >&2
+        echo "  → inspect: git -C \"$VAULT_DIR\" stash show -p stash@{0}" >&2
+        return 1
+    fi
     echo "✓ Updated"
 }
 
 cmd_sync() {
-    cmd_update
+    # A failed pull must never fall through to apply — that is how conflict
+    # markers get committed and pushed.
+    cmd_update || return 1
     cmd_apply
 }
 


### PR DESCRIPTION
## Root cause

`cvault sync` on work-wsl published conflict markers to the vault. Not because the script ignored an error — because there was no error to ignore.

`git pull --rebase --autostash` **exits 0** when the pull succeeds and only the autostash *reapply* conflicts. Git reports that as a warning. So:

1. `set -e` (line 16) never fired.
2. `cmd_update` printed `✓ Updated`.
3. `cmd_sync` fell through to `cmd_apply`.
4. `cmd_apply` ran `git add -A` over a tree with unmerged paths — staging conflict markers as ordinary text, and re-adding files an upstream commit had deliberately deleted.
5. It committed and pushed.

The existing `in_progress()` guard cannot catch this: a failed autostash reapply leaves no `MERGE_HEAD` and no `rebase-merge/` directory. It is not a merge in progress. `conflicted_files()` **would** have caught it, but `cmd_apply` never called it.

## Reproduction

Clone, change a line upstream, change the same line locally and leave it unstaged, then pull:

| Signal | Value |
|---|---|
| `git pull --rebase --autostash` exit code | `0` |
| stash entries before → after | `0` → `1` |
| unmerged paths (`--diff-filter=U`) | the file |
| conflict markers written to disk | yes |

## Fix

Guard both ends, so either alone would have stopped it:

- **`cmd_update`** captures stash depth before and after the pull. A new entry means the autostash survived and the tree may hold markers — abort, and point at `stash@{0}` instead of reporting success. Depth comparison rather than grepping `git stash list` for `autostash`, so a stale entry from a previous failure can't make the check permanently true.
- **`cmd_apply`** consults the already-existing `conflicted_files()` before `git add -A`, and refuses when anything is unmerged or a merge is mid-flight.
- **`cmd_sync`** aborts explicitly on `cmd_update` failure rather than relying on `set -e` semantics across a function call.

## Verification

- `bash -n` clean; `shellcheck -S warning` clean.
- Failure state reproduced in a throwaway repo (table above). In that state `after > before` is true and `conflicted_files()` is non-empty, so both new guards trip.

## Fallout

The content damage this caused is repaired in `Drewtopia/claude-vault#2`.