### PR TITLE
feat(wsl): shim op to the Windows op.exe

### DIFF
--- a/home/.chezmoiignore.tmpl
+++ b/home/.chezmoiignore.tmpl
@@ -47,6 +47,13 @@ Library
 .wezterm.lua
 {{ end }}
 
+# The op shim delegates to the Windows op.exe over WSL interop, because the
+# Linux-native op has no IPC path to 1Password for Windows. Only WSL needs it;
+# elsewhere the platform-native op talks to its own desktop app directly.
+{{ if not .is_wsl }}
+.local/bin/op
+{{ end }}
+
 # az-CLI Azure DevOps token-mint helper is the headless fallback in the WSL2
 # credential chain (see dot_config/git/config.tmpl). Only work WSL2 needs it;
 # everywhere else (mac, personal WSL, Windows) uses GCM alone, so leave any

--- a/home/dot_local/bin/executable_op.tmpl
+++ b/home/dot_local/bin/executable_op.tmpl
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# 1Password CLI shim for WSL.
+#
+# The Linux-native op (/usr/bin/op) has no IPC channel to 1Password for
+# Windows. App integration is same-OS: the Linux CLI expects 1Password for
+# Linux plus a running PolKit authentication agent. With no unlock authority
+# to ask, it falls back to prompting for the account password on every
+# invocation, which makes chezmoi's onepasswordRead unusable non-interactively.
+#
+# op.exe invoked through WSL interop reaches the Windows app over Native
+# Messaging and authenticates against the app's unlocked session. Confirmed by
+# `op.exe vault list` returning vaults with no prompt while `op whoami` on the
+# Linux binary reported "account is not signed in".
+#
+# Note: `op whoami` reports session-token state, not app-integration state, and
+# still prints "account is not signed in" through this shim. That is expected.
+# Commands that need vault data authenticate transparently.
+set -euo pipefail
+
+# Resolved at chezmoi render time; the WinGet hash suffix is wildcarded so a
+# CLI version bump does not invalidate the path.
+OP_EXE="{{ glob (printf "/mnt/c/Users/%s/AppData/Local/Microsoft/WinGet/Packages/AgileBits.1Password.CLI_*/op.exe" .chezmoi.username) | first }}"
+
+# WinGet can relocate the package on reinstall. Re-resolve rather than fail.
+# The Windows profile is capitalised (AndrewCl) where the Linux user is not;
+# this matches because /mnt/c is mounted case-insensitively.
+if [ -z "$OP_EXE" ] || [ ! -f "$OP_EXE" ]; then
+    OP_EXE=$(ls -1 /mnt/c/Users/"$(id -un)"/AppData/Local/Microsoft/WinGet/Packages/AgileBits.1Password.CLI_*/op.exe 2>/dev/null | head -n1 || true)
+fi
+
+if [ -z "$OP_EXE" ]; then
+    echo "op: 1Password CLI for Windows not found." >&2
+    echo "    Install it on the Windows host:  winget install 1Password.CLI" >&2
+    echo "    The Linux op cannot reach 1Password for Windows." >&2
+    exit 127
+fi
+
+exec "$OP_EXE" "$@"


### PR DESCRIPTION
## Symptom

`chezmoi status` / `chezmoi apply` on work-wsl died with:

```
error calling onepasswordRead: /usr/bin/op signin --raw: exit status 1
```

Interactively, `op` demanded the 1Password **account password** on every call instead of prompting the Windows desktop app.

## Root cause

The Linux-native `op` has **no IPC channel to 1Password for Windows**. App integration is same-OS: per [1password.dev/cli/app-integration](https://www.1password.dev/cli/app-integration/), the Linux CLI requires *1Password for Linux* plus a running PolKit authentication agent. With no unlock authority to ask, `op` correctly falls back to the account password. Nothing was misconfigured.

`op.exe` invoked through WSL interop reaches the Windows app over Native Messaging.

Evidence gathered on work-wsl (`VEC-0jP9La2c4ea`, WSL2 on Windows host `VEC-0JP9LA2C4EA`):

| Probe | Result |
|---|---|
| `/usr/bin/op whoami` | `account is not signed in` |
| `op.exe --debug whoami` | `NM request: NmRequestAccounts` → `NM response: Success` |
| `op.exe vault list` (app unlocked) | vaults returned, `rc=0`, no prompt |
| `op.exe` output CR bytes | `0` — emits LF, no newline translation needed |

Note `op whoami` reports *session-token* state, not app-integration state, and still says "account is not signed in" even when integration works. It is a red herring; commands that need vault data authenticate transparently.

## Fix

A WSL-only `~/.local/bin/op` that execs `op.exe`. `~/.local/bin` already precedes `/usr/bin` on PATH.

Chosen over `[onepassword] command` in `.chezmoi.toml.tmpl` because that template calls `onepasswordRead` **while rendering itself** (for `$name`/`$email`), and chezmoi reads the config only after rendering — so a config setting cannot fix `chezmoi init`. The shim fixes interactive use, `chezmoi apply`, and `chezmoi init` alike.

The WinGet path is resolved by `glob` at render time (wildcarding the package hash so a CLI version bump doesn't break it) and re-resolved at runtime if the package moves. Gated in `.chezmoiignore.tmpl` on `not .is_wsl`, matching the existing `.bashrc` / `.wezterm.lua` idiom.

## Verification

Structural, on the mac:
- `.local/bin/op` is ignored, not pending, and no stray file exists.

End-to-end, on work-wsl with the app unlocked (user authenticated at the Windows desktop):
- `command -v op` in a login shell → `/home/andrewcl/.local/bin/op`
- `op vault list` → `rc=0`, vaults returned, **no account password**
- `chezmoi execute-template '{{ onepasswordRead "op://Employee/Identity/handle" }}'` → `rc=0`, 12 bytes, **0 trailing CR**
- `chezmoi status` → `rc=0`, no `onepasswordRead` error
- `chezmoi cat ~/.config/shell/015-vault.sh` → renders 338 bytes, empty stderr

## Known limits

- Desktop-app integration **requires a human at the Windows desktop** when the app is locked. `op` then blocks on an unlock dialog rather than erroring. Over ssh or headless it will hang until timeout — a different failure mode than the previous `exit status 1`. Automation on that box still wants a service-account token.
- `op.exe` is a Windows binary: it cannot read Linux paths, so `op inject -i /home/...` would fail. Not used by any current template.