### PR TITLE
docs(claude): refresh memory topic list in CLAUDE.md

### DIFF
--- a/home/dot_claude/CLAUDE.md.tmpl
+++ b/home/dot_claude/CLAUDE.md.tmpl
@@ -42,7 +42,7 @@ These rules are **ABSOLUTE**. No exceptions.
 
 Two systems load at session start:
 
-- `@~/.claude/memory/memory.md` — index of accumulated knowledge (tools/, projects.md, personal.md, SESSION_LOG.md, general.md). Load specific topic files only when relevant.
+- `@~/.claude/memory/memory.md` — index of accumulated knowledge (tools/, domain/, projects.md, personal.md, working-patterns.md, SESSION_LOG.md, general.md). Load specific topic files only when relevant.
 - `~/.claude/rules/` — behavioral rules. Loaded automatically by Claude Code; no reference needed here.
 
 Maintaining memory:
@@ -72,4 +72,4 @@ Project MEMORY.md has a 200-line budget — auto-memory loads only the first 200
 
 ---
 
-*Last updated: 2026-05-12*
+*Last updated: 2026-07-10*


### PR DESCRIPTION
Index line omitted working-patterns.md and domain/, both live in the
vault and listed in memory.md.
