### PR TITLE
chore(topgrade): drop -y from skills update so lock orphans self-clean

### DIFF
--- a/home/.chezmoiscripts/common/run_onchange_after_60-install-skills.ps1.tmpl
+++ b/home/.chezmoiscripts/common/run_onchange_after_60-install-skills.ps1.tmpl
@@ -6,7 +6,7 @@
 # run_onchange: fires only when this rendered script changes, i.e. when
 # .chezmoidata/skills.yaml changes the declared repo/skill set. Its job is
 # ADDING newly-declared skills. Ongoing UPDATES are owned by topgrade
-# (`npx skills update -g -y`, see dot_config/topgrade.toml).
+# (`pnx skills update -g`, see dot_config/topgrade.toml).
 
 # Continue past per-repo failures so one bad repo cannot abort siblings.
 $ErrorActionPreference = "Continue"

--- a/home/.chezmoiscripts/common/run_onchange_after_60-install-skills.sh.tmpl
+++ b/home/.chezmoiscripts/common/run_onchange_after_60-install-skills.sh.tmpl
@@ -9,7 +9,7 @@
 # run_onchange: fires only when this rendered script changes, i.e. when
 # .chezmoidata/skills.yaml changes the declared repo/skill set. Its job is
 # ADDING newly-declared skills. Ongoing UPDATES are owned by topgrade
-# (`npx skills update -g -y`, see dot_config/topgrade.toml).
+# (`pnx skills update -g`, see dot_config/topgrade.toml).
 
 if ! command -v npx >/dev/null 2>&1; then
     echo "[skills] npx not on PATH; skipping"

--- a/home/.chezmoitemplates/topgrade.toml
+++ b/home/.chezmoitemplates/topgrade.toml
@@ -116,7 +116,9 @@ auto_retry = 1
 # Invoke via `pnx`, not `npx`: the skills package declares
 # devEngines.packageManager = pnpm, so npm trips EBADDEVENGINES on a
 # name mismatch. pnx (alias of pnpm dlx) runs it under pnpm and satisfies it.
-agent-skills = "pnx skills update -g -y"
+# No -y: attended runs surface the "deleted upstream" prompt so lock-file
+# entries self-clean; unattended runs (no TTY) skip prompts automatically.
+agent-skills = "pnx skills update -g"
 # tv-channels: pull the community channel set. Moved out of chezmoi apply
 # (was run_before_05-update-tv-channels) so apply stays fast; tv skips
 # channels that already exist, chezmoi still owns custom overrides.

--- a/home/dot_claude/skills/audit-skill-repos/SKILL.md
+++ b/home/dot_claude/skills/audit-skill-repos/SKILL.md
@@ -7,7 +7,7 @@ description: Use when checking whether the upstream skill repos tracked in chezm
 
 Diff every upstream skill repo listed in chezmoi's `skills.yaml` against what's tracked, surface new / renamed / removed skills, and — on approval — reconcile `skills.yaml`.
 
-This is a **local, never-committed** skill (lives in `~/.claude/skills/`, outside the chezmoi repo).
+This skill is **chezmoi-managed** (source: `home/dot_claude/skills/audit-skill-repos/`). Edit the source, or edit the target and `chezmoi add` it — a target-only edit gets reverted on the next apply.
 
 ## Key file
 
@@ -55,6 +55,7 @@ This is a **local, never-committed** skill (lives in `~/.claude/skills/`, outsid
 - **`personal/` and `deprecated/`** — don't propose these unless asked; they're not meant for redistribution.
 - **PromptScript "failure" is cosmetic.** Command-style skills (`disable-model-invocation: true`) print `✗ … PromptScript does not support global skill installation` under a "Failed to install N" banner, yet the real install succeeds — `~/.agents/skills/<name>` payload + `~/.claude/skills/<name>` symlink both land. Verify on disk, don't trust the exit banner. Same quirk hits already-working skills (grilling, triage).
 - **Removing a skill** needs two edits: drop from `skills.yaml` AND add `.claude/skills/<name>` + `.agents/skills/<name>` lines to `home/.chezmoiremove.tmpl` — chezmoi doesn't manage the `.agents` payload store, so otherwise the payload orphans on every machine.
+- **Lock file orphans (third cleanup).** The skills CLI tracks installs in `$XDG_STATE_HOME/skills/.skill-lock.json` (`~/.local/state/skills/` here; falls back to `~/.agents/.skill-lock.json`). `.chezmoiremove` deletes dirs but never touches the lock, and `npx skills remove` only matches on-disk skills — it can't scrub orphaned entries. Result: `skills update -g` warns "appear to have been deleted upstream" forever (topgrade's `-y` just skips the prompt each run). Fix: back up the lock, then pop the stale names from its `skills` object with python/jq. (2026-07-10: diagnose, to-issues, to-prd, zoom-out, write-a-skill.)
 - **Don't commit unless asked.** Editing `skills.yaml` stages a change; leave the git commit to the user.
 
 ## Quick reference


### PR DESCRIPTION
## Summary
- Drop `-y` from topgrade's `agent-skills` command (`pnx skills update -g`) so attended runs surface the skills CLI's "deleted upstream" prompt and orphaned lock-file entries self-clean; unattended runs (no TTY) skip prompts automatically, so nothing hangs.
- Update stale comment references in both `run_onchange` install scripts to match the new command form.
- Document the lock-orphan gotcha in the `audit-skill-repos` skill: `.chezmoiremove` deletes skill dirs but never touches `$XDG_STATE_HOME/skills/.skill-lock.json`, and `npx skills remove` can't scrub entries whose dirs are already gone.
- Fix the skill's stale claim of being local/unmanaged — it is chezmoi-managed, so target-only edits get reverted on apply.

## Test plan
- [x] `chezmoi apply ~/.config/topgrade.toml` deploys the new command
- [x] Orphaned lock entries removed; `skills update -g` reports "All global skills are up to date" with no deletion warning