### PR TITLE
chore(topgrade): adopt native skills step from 17.7.0

### DIFF
--- a/home/.chezmoiscripts/common/run_onchange_after_60-install-skills.ps1.tmpl
+++ b/home/.chezmoiscripts/common/run_onchange_after_60-install-skills.ps1.tmpl
@@ -5,8 +5,8 @@
 #
 # run_onchange: fires only when this rendered script changes, i.e. when
 # .chezmoidata/skills.yaml changes the declared repo/skill set. Its job is
-# ADDING newly-declared skills. Ongoing UPDATES are owned by topgrade
-# (`pnx skills update -g`, see dot_config/topgrade.toml).
+# ADDING newly-declared skills. Ongoing UPDATES are owned by topgrade's
+# native `skills` step (17.7.0+, see .chezmoitemplates/topgrade.toml).
 
 # Continue past per-repo failures so one bad repo cannot abort siblings.
 $ErrorActionPreference = "Continue"

--- a/home/.chezmoiscripts/common/run_onchange_after_60-install-skills.sh.tmpl
+++ b/home/.chezmoiscripts/common/run_onchange_after_60-install-skills.sh.tmpl
@@ -8,8 +8,8 @@
 #
 # run_onchange: fires only when this rendered script changes, i.e. when
 # .chezmoidata/skills.yaml changes the declared repo/skill set. Its job is
-# ADDING newly-declared skills. Ongoing UPDATES are owned by topgrade
-# (`pnx skills update -g`, see dot_config/topgrade.toml).
+# ADDING newly-declared skills. Ongoing UPDATES are owned by topgrade's
+# native `skills` step (17.7.0+, see .chezmoitemplates/topgrade.toml).
 
 if ! command -v npx >/dev/null 2>&1; then
     echo "[skills] npx not on PATH; skipping"

--- a/home/.chezmoitemplates/topgrade.toml
+++ b/home/.chezmoitemplates/topgrade.toml
@@ -111,14 +111,10 @@ auto_retry = 1
 # Lowercase, space-free names so `--custom-commands <name>` needs no
 # quoting or case-matching on the CLI.
 #
-# agent-skills: chezmoi's run_onchange install-skills script ADDS declared
-# skills (fires on skills.yaml change); topgrade owns UPDATING them.
-# Invoke via `pnx`, not `npx`: the skills package declares
-# devEngines.packageManager = pnpm, so npm trips EBADDEVENGINES on a
-# name mismatch. pnx (alias of pnpm dlx) runs it under pnpm and satisfies it.
-# No -y: attended runs surface the "deleted upstream" prompt so lock-file
-# entries self-clean; unattended runs (no TTY) skip prompts automatically.
-agent-skills = "pnx skills update -g"
+# Agent skills: chezmoi's run_onchange install-skills script ADDS declared
+# skills (fires on skills.yaml change); topgrade's native `skills` step
+# (17.7.0+) owns UPDATING them — no custom command needed.
+#
 # tv-channels: pull the community channel set. Moved out of chezmoi apply
 # (was run_before_05-update-tv-channels) so apply stays fast; tv skips
 # channels that already exist, chezmoi still owns custom overrides.


### PR DESCRIPTION
topgrade v17.7.0 ([release notes](https://github.com/topgrade-rs/topgrade/releases/tag/v17.7.0)) fixes its native `skills` step to locate `.skill-lock.json` via `XDG_STATE_HOME` (topgrade-rs/topgrade#2114). Until now the step only checked `~/.agents/` and silently skipped on this setup, which is why the `agent-skills` custom command existed.

Changes:
- Drop the `agent-skills = "pnx skills update -g"` custom command; the native step (`npx skills update --global`) takes over once topgrade self-updates to 17.7.0 via the mise step.
- Correct comments in the install-skills scripts that pointed at the custom command.

The pnx wrapper's premise was misdiagnosed: no published version of the `skills` package declares `devEngines` (verified all 83 versions on the npm registry), so npx runs it fine. The EBADDEVENGINES error occurs only when the command is launched from inside a project whose own package.json declares `devEngines.packageManager: pnpm`. If the step ever fails that way, rerun from $HOME.

Note: one-run gap — installed 17.6.2 still skips the skills step; the run after topgrade updates itself picks it up.

Config validated: `topgrade --config home/.chezmoitemplates/topgrade.toml --dry-run --only chezmoi` parses and runs clean.