### PR TITLE
fix(chezmoi): ignore junction-based skills on personal Windows

### DIFF
--- a/home/.chezmoiignore.tmpl
+++ b/home/.chezmoiignore.tmpl
@@ -138,6 +138,13 @@ README.md
 !.claude/hooks/
 !.claude/skills/
 {{-   if eq .chezmoi.os "windows" }}
+# Personal Windows: the skills installer creates community skills as NTFS
+# junctions under ~/.claude/skills, which chezmoi cannot read (irregular file
+# type). Ignore everything there except the chezmoi-managed skills.
+.claude/skills/*
+{{-     range glob (joinPath .chezmoi.sourceDir "dot_claude/skills/*") }}
+!.claude/skills/{{ base . }}
+{{-     end }}
 # Personal Windows: chezmoi-managed symlink (requires Developer Mode).
 !.claude/rules
 {{-   else }}


### PR DESCRIPTION
## Problem

`chezmoi status`/`apply` on drew-pd aborts with:

```
chezmoi: .claude/skills/diagnose: C:/Users/Andrew/.claude/skills/diagnose: unsupported file type 0o2000000: unknown type
```

`0o2000000` is Go's `ModeIrregular`. The community-skills installer creates NTFS junctions under `~/.claude/skills` (17 on drew-pd) pointing at `~/.agents/skills`, and chezmoi cannot read junctions. `.chezmoiignore` un-ignores `.claude/skills/`, so chezmoi walks the dir and trips on the first junction.

## Fix

On Windows, re-ignore `.claude/skills/*` and allowlist only the chezmoi-managed skills, generated via `glob` over the source dir so the list self-maintains. Same approach as the existing `.local/bin` junction workaround.

## Verification

- Local darwin render of `.chezmoiignore.tmpl` unchanged
- On drew-pd against a throwaway clone of this branch: `chezmoi status ~/.claude` exits 0, junction error gone, legit pending changes still reported