### PR TITLE
fix(claude): use Edit() deny rules for dotenv files

### DIFF
--- a/home/dot_claude/modify_settings.json.tmpl
+++ b/home/dot_claude/modify_settings.json.tmpl
@@ -71,8 +71,8 @@ managed=$(cat <<'CHEZMOI_SETTINGS_EOF'
       "Read(**/.env)",
       "Read(**/.env.*)",
       "Read(**/secrets/**)",
-      "Write(**/.env)",
-      "Write(**/.env.*)"
+      "Edit(**/.env)",
+      "Edit(**/.env.*)"
     ]
   },
   "hooks": {


### PR DESCRIPTION
## Summary
- Claude Code warned at startup: `Write(**/.env)` / `Write(**/.env.*)` deny rules are not matched by file permission checks — only `Edit(path)` rules cover file-editing tools (Write included).
- Swapped both deny rules to `Edit(**/.env)` / `Edit(**/.env.*)` in the managed settings template.

## Notes
- Live `~/.claude/settings.json` patched to match; the modify-script merge unions managed entries, so the stale `Write(...)` rules would have been re-added on every apply if only the live file were fixed.
- `Read(**/.env)` rules unchanged — those match correctly.
