### PR TITLE
chore(claude): consolidate skill plugins onto mattpocock-skills

### DIFF
--- a/home/.chezmoidata/claude.toml
+++ b/home/.chezmoidata/claude.toml
@@ -15,6 +15,7 @@ caveman                   = "JuliusBrussee/caveman"
 "claude-brain-sync"       = "toroleapinc/claude-brain"
 "claude-plugins-official" = "anthropics/claude-plugins-official"
 "karpathy-skills"         = "forrestchang/andrej-karpathy-skills"
+mattpocock                = "mattpocock/skills"
 "obsidian-skills"         = "kepano/obsidian-skills"
 qmd                       = "tobi/qmd"
 "superpowers-extended-cc-marketplace" = "pcvelz/superpowers"
@@ -33,7 +34,12 @@ worktrunk                 = "max-sixty/worktrunk"
 "hookify@claude-plugins-official"                  = true
 "claude-md-management@claude-plugins-official"     = true
 "superpowers@claude-plugins-official"              = false
-"superpowers-extended-cc@superpowers-extended-cc-marketplace" = true
+# Retired Jul 2026 in favour of mattpocock-skills, which covers the same
+# ground with one skill per job: test-driven-development→tdd,
+# requesting-code-review→code-review, systematic-debugging→diagnosing-bugs,
+# writing-plans→to-spec, brainstorming→grilling. Its using-superpowers skill
+# also injected itself into every session's system prompt.
+"superpowers-extended-cc@superpowers-extended-cc-marketplace" = false
 "claude-code-setup@claude-plugins-official"        = true
 "security-guidance@claude-plugins-official"        = true
 "explanatory-output-style@claude-plugins-official" = true
@@ -45,15 +51,27 @@ worktrunk                 = "max-sixty/worktrunk"
 
 [plugins.dev_computer]
 "qmd@qmd"                                 = true
-"code-review@claude-plugins-official"     = true
-"feature-dev@claude-plugins-official"     = true
+# Both retired Jul 2026 — mattpocock-skills covers them (code-review, and
+# to-spec → implement → codebase-design for feature work), and having three
+# plugins answer the same trigger made skill selection worse, not better.
+"code-review@claude-plugins-official"     = false
+"feature-dev@claude-plugins-official"     = false
 "typescript-lsp@claude-plugins-official"  = true
 "commit-commands@claude-plugins-official" = true
 "playwright@claude-plugins-official"      = true
 "code-simplifier@claude-plugins-official" = true
 "plugin-dev@claude-plugins-official"      = true
 "caveman@caveman"                         = true
+# Ships the 22 stable engineering/ + productivity/ skills, pinned to
+# plugin.json's version. The 9 misc/ + in-progress/ skills it excludes
+# stay on the `npx skills` path in .chezmoidata/skills.yaml.
+"mattpocock-skills@mattpocock"            = true
 "obsidian@obsidian-skills"                = true
 "greptile@claude-plugins-official"        = false
-"ecc@ecc"                                 = true
+# Retired Jul 2026: 889 skills + 306 agents, all of whose names and
+# descriptions load at session start. The context cost outweighed the use we
+# got from it, and it duplicated mattpocock-skills across tdd, code-review,
+# research, plan and feature-dev. Re-enable if the orchestration pipelines
+# (orch-*, multi-*, gan-*) are ever actually wanted.
+"ecc@ecc"                                 = false
 "worktrunk@worktrunk"                     = true

--- a/home/.chezmoidata/skills.yaml
+++ b/home/.chezmoidata/skills.yaml
@@ -7,49 +7,23 @@
 # .chezmoiexternal.toml.tmpl, which went stale on upstream refactors.
 skill_repos:
   - repo: mattpocock/skills
-    # Hidden-subdir skills (misc/, personal/, deprecated/, in-progress/) are excluded from
-    # `npx skills add mattpocock/skills -l` BUT can still be installed by
-    # name via the --skill flag, which the reconciler script uses.
+    # The stable engineering/ + productivity/ skills now come from the
+    # `mattpocock-skills@mattpocock` Claude Code plugin (see .chezmoidata/
+    # claude.toml). Upstream's plugin.json enumerates them, so their renames
+    # and removals no longer need hand-reconciling here — the trade-off is
+    # they invoke namespaced (`mattpocock-skills:tdd`, not `tdd`).
     #
-    # Reconciled against upstream v1.0.0 (Jun 2026 "design skills" refactor):
-    #   write-a-skill → writing-great-skills (replaced)
-    #   diagnose      → diagnosing-bugs (renamed)
-    #   zoom-out      → removed upstream, no replacement
+    # Only misc/ and in-progress/ remain on this path: plugin.json omits
+    # them, and `npx skills add -l` hides them, but --skill installs them
+    # by name anyway (which is what the reconciler script uses).
     #
-    # Reconciled against upstream v1.1.0 (Jul 2026):
-    #   to-issues, to-prd → unified upstream into to-spec + to-tickets
-    #   wayfinder         → graduated in-progress/ to engineering/ (now stable)
-    # Stale on-disk dirs purged via .chezmoiremove.tmpl.
+    # in-progress/ is unstable upstream — expect renames and breakage.
     skills:
-      # productivity/
-      - grill-me
-      - grilling
-      - writing-great-skills
-      - teach
-      - handoff
-      # engineering/
-      - diagnosing-bugs
-      - grill-with-docs
-      - improve-codebase-architecture
-      - codebase-design
-      - domain-modeling
-      - resolving-merge-conflicts
-      - ask-matt
-      - prototype
-      - implement
-      - setup-matt-pocock-skills
-      - tdd
-      - to-spec
-      - to-tickets
-      - triage
-      - code-review
-      - research
-      - wayfinder
-      # misc/ (hidden but installable by name)
+      # misc/
       - git-guardrails-claude-code
       - migrate-to-shoehorn
       - scaffold-exercises
-      # in-progress/ (unstable upstream; may rename/break — installable by name)
+      # in-progress/
       - wizard
       - loop-me
       - writing-fragments

--- a/home/.chezmoiremove.tmpl
+++ b/home/.chezmoiremove.tmpl
@@ -64,3 +64,20 @@
 .claude/skills/to-prd
 .agents/skills/to-issues
 .agents/skills/to-prd
+
+# mattpocock/skills v1.2.0 (Jul 2026): the stable engineering/ + productivity/
+# skills moved from `npx skills` to the mattpocock-skills@mattpocock plugin
+# (see .chezmoidata/claude.toml). Sweep the old copies so they don't shadow
+# the plugin's namespaced versions with a stale duplicate. Exactly the 22
+# names in upstream's .claude-plugin/plugin.json — misc/ and in-progress/
+# are deliberately absent, they stay on the `npx skills` path.
+{{- $pluginSkills := list
+  "ask-matt" "code-review" "codebase-design" "diagnosing-bugs" "domain-modeling"
+  "grill-with-docs" "implement" "improve-codebase-architecture" "prototype"
+  "research" "resolving-merge-conflicts" "setup-matt-pocock-skills" "tdd"
+  "to-spec" "to-tickets" "triage" "wayfinder"
+  "grill-me" "grilling" "handoff" "teach" "writing-great-skills" }}
+{{- range $pluginSkills }}
+.claude/skills/{{ . }}
+.agents/skills/{{ . }}
+{{- end }}

--- a/home/dot_claude/skills/audit-skill-repos/SKILL.md
+++ b/home/dot_claude/skills/audit-skill-repos/SKILL.md
@@ -9,9 +9,13 @@ Diff every upstream skill repo listed in chezmoi's `skills.yaml` against what's 
 
 This skill is **chezmoi-managed** (source: `home/dot_claude/skills/audit-skill-repos/`). Edit the source, or edit the target and `chezmoi add` it — a target-only edit gets reverted on the next apply.
 
-## Key file
+## Key files
 
-`~/.local/share/chezmoi/home/.chezmoidata/skills.yaml` — the source of truth. Each entry: a GitHub `repo:` plus the `skills:` list to install. A `run_onchange` script reconciles on change; topgrade owns ongoing `npx skills update`.
+`~/.local/share/chezmoi/home/.chezmoidata/skills.yaml` — source of truth for the `npx skills` path. Each entry: a GitHub `repo:` plus the `skills:` list to install. A `run_onchange` script reconciles on change; topgrade owns ongoing `npx skills update`.
+
+`~/.local/share/chezmoi/home/.chezmoidata/claude.toml` — source of truth for the **plugin** path (`[marketplaces]` + profile-gated `[plugins.*]`). Skills delivered by a plugin are enumerated by that plugin's own `.claude-plugin/plugin.json`, so they need no per-name tracking here.
+
+**mattpocock/skills is split across both.** Its 22 stable engineering/ + productivity/ skills ship via the `mattpocock-skills@mattpocock` plugin; only misc/ and in-progress/ (which `plugin.json` omits) remain in `skills.yaml`. When auditing that repo, diff upstream against `plugin.json`'s array **and** the `skills.yaml` list — a skill graduating from in-progress/ to engineering/ likely means dropping it from `skills.yaml` (the plugin now covers it), not renaming it.
 
 ## Workflow
 
@@ -55,6 +59,7 @@ This skill is **chezmoi-managed** (source: `home/dot_claude/skills/audit-skill-r
 - **`personal/` and `deprecated/`** — don't propose these unless asked; they're not meant for redistribution.
 - **PromptScript "failure" is cosmetic.** Command-style skills (`disable-model-invocation: true`) print `✗ … PromptScript does not support global skill installation` under a "Failed to install N" banner, yet the real install succeeds — `~/.agents/skills/<name>` payload + `~/.claude/skills/<name>` symlink both land. Verify on disk, don't trust the exit banner. Same quirk hits already-working skills (grilling, triage).
 - **Removing a skill** needs two edits: drop from `skills.yaml` AND add `.claude/skills/<name>` + `.agents/skills/<name>` lines to `home/.chezmoiremove.tmpl` — chezmoi doesn't manage the `.agents` payload store, so otherwise the payload orphans on every machine.
+- **Prefer the plugin path when a repo offers one.** A `.claude-plugin/marketplace.json` upstream means the repo can be registered in `claude.toml` instead, which kills the per-name reconciliation entirely (upstream's `plugin.json` becomes the list) and pins to its `version` field. Costs: skills invoke namespaced (`<plugin>:<skill>`), and you can't cherry-pick — you get exactly what `plugin.json` enumerates. Check `plugin.json` before assuming parity; its `skills` field *adds to* the default `skills/` scan rather than replacing it, so a repo with skills one level deep under `skills/` ships more than the array lists.
 - **Lock file orphans (third cleanup).** The skills CLI tracks installs in `$XDG_STATE_HOME/skills/.skill-lock.json` (`~/.local/state/skills/` here; falls back to `~/.agents/.skill-lock.json`). `.chezmoiremove` deletes dirs but never touches the lock, and `npx skills remove` only matches on-disk skills — it can't scrub orphaned entries. Result: `skills update -g` warns "appear to have been deleted upstream" forever (topgrade's `-y` just skips the prompt each run). Fix: back up the lock, then pop the stale names from its `skills` object with python/jq. (2026-07-10: diagnose, to-issues, to-prd, zoom-out, write-a-skill.)
 - **Don't commit unless asked.** Editing `skills.yaml` stages a change; leave the git commit to the user.
 


### PR DESCRIPTION
## What

mattpocock/skills now publishes a Claude Code plugin alongside the `npx skills` path. Its `.claude-plugin/plugin.json` enumerates the 22 stable `engineering/` + `productivity/` skills, so hand-tracking those names in `skills.yaml` is no longer necessary.

Split across both install paths:

| Path | Covers |
|---|---|
| `mattpocock-skills@mattpocock` plugin (v1.2.0) | the 22 stable skills |
| `skills.yaml` via `npx skills` | the 9 `misc/` + `in-progress/` skills `plugin.json` omits |

Also swept the 22 superseded copies from `~/.claude/skills` and `~/.agents/skills` via `.chezmoiremove.tmpl`, so they don't shadow the plugin's namespaced versions.

**Trade-off:** these now invoke namespaced — `mattpocock-skills:tdd`, not `tdd`.

## Plugins suppressed

With the overlap resolved, four plugins that answered the same triggers are set to `false`:

- **`ecc@ecc`** — 889 skills + 306 agents, all names and descriptions loading at session start. Biggest context cost; duplicated mattpocock across tdd, code-review, research, plan, feature-dev.
- **`superpowers-extended-cc`** — `test-driven-development`→`tdd`, `requesting-code-review`→`code-review`, `systematic-debugging`→`diagnosing-bugs`, `writing-plans`→`to-spec`, `brainstorming`→`grilling`. Its `using-superpowers` skill also injected itself into every session's system prompt.
- **`code-review@claude-plugins-official`**, **`feature-dev@claude-plugins-official`** — direct duplicates.

## Applying this on other machines

`enabledPlugins` in `claude.toml` is a **floor, not an override** — `modify_settings.json.tmpl` lets runtime state win, deliberately, so `/plugin` toggles survive an apply. Consequence:

- Fresh machine → no runtime key, floor applies, plugins never enable. Nothing to do.
- Machine where these are already enabled → `chezmoi apply` alone won't disable them. Run:

  ```
  claude plugin disable ecc@ecc
  claude plugin disable superpowers-extended-cc@superpowers-extended-cc-marketplace
  claude plugin disable code-review@claude-plugins-official
  claude plugin disable feature-dev@claude-plugins-official
  ```

## Verified on darwin

- 22 stale copies gone from both `~/.claude/skills` and `~/.agents/skills`; the 9 in-progress/misc remain
- `.skill-lock.json` scrubbed of 22 orphans (18 entries left, 0 orphaned) — backup at `~/.local/state/skills/.skill-lock.json.bak-pre-mattpocock-plugin`
- plugin installed, v1.2.0, enabled
- all four disables survive a re-apply (idempotent)

## Unexplained

On the first `chezmoi apply` the mattpocock marketplace didn't register — `claude plugin marketplace list` showed 9, no mattpocock. Re-running the identical rendered script standalone registered all 10 fine. Not reproduced, cause unknown. Worth watching on the next machine's apply.