### PR TITLE
fix(ssh): route github over port 443 on all platforms

### DIFF
--- a/home/dot_ssh/config.tmpl
+++ b/home/dot_ssh/config.tmpl
@@ -14,10 +14,10 @@ Host *
 
 Host github.com
   User git
-{{- if .is_wsl }}
+  # Port 22 blocked by corporate firewall; also needed on Windows because
+  # work-WSL git routes SSH through ssh.exe, which reads the Windows config.
   Hostname ssh.github.com
   Port 443
-{{- end }}
 
 # Host macbook-air-m3
 #  User twp


### PR DESCRIPTION
The ssh.github.com:443 override was gated on is_wsl, so the Windows config kept the default github.com:22. Work-WSL git sets core.sshCommand to Windows ssh.exe (for the 1Password agent), and that binary reads the Windows ssh config — so SSH remotes in WSL fell back to port 22, which the corporate firewall blocks.

Ungate the override. GitHub serves SSH on ssh.github.com:443 on every network, so it is safe unconditionally.