### PR TITLE
fix(claude): prune retired deny rules from merged settings

### DIFF
--- a/home/dot_claude/modify_settings.json.tmpl
+++ b/home/dot_claude/modify_settings.json.tmpl
@@ -240,4 +240,8 @@ printf '%s' "$existing" | jq --argjson m "$managed" '
   # bind runtime input to $e first: jq args are call-by-name filters, so passing
   # "." rebinds b to the reduce accumulator mid-merge and drops runtime-only keys.
   . as $e | dm($m; $e)
+  # Tombstones: the merge is add-only (arrays union), so retiring a managed
+  # entry in this file cannot remove it from the live settings. List retired
+  # entries here to prune them on the next apply.
+  | .permissions.deny -= ["Write(**/.env)", "Write(**/.env.*)"]
 ' | tr -d '\r'


### PR DESCRIPTION
## Problem

`modify_settings.json.tmpl` merges the managed settings block as a floor under the live runtime file, unioning arrays so Claude's own writes survive. That merge is **add-only**: removing an entry from the managed block never removes it from `~/.claude/settings.json`.

Result — the retired `Write(**/.env*)` deny rules kept reappearing at startup with:

```
Write(**/.env) is not matched by file permission checks
```

## Fix

Add an explicit tombstone step after the merge to prune retired entries.

File permission checks only consult `Edit(path)` rules; the `Edit(**/.env*)` equivalents are already in the managed deny list, so protection is unchanged.

## Verification

After apply, the live deny list contains only the intended entries:

```
Read(**/.env)
Read(**/.env.*)
Edit(**/.env)
Edit(**/.env.*)
```

`chezmoi diff ~/.claude/settings.json` is empty — converged.

## Note

The tombstone runs after the merge, so it outranks the managed block. If a `Write(...)` rule is ever legitimately re-added to the managed deny list, it will be stripped on the next apply. The inline comment flags this.
