### PR TITLE
chore(claude): manage the i-have-adhd plugin via chezmoi

### DIFF
--- a/home/.chezmoidata/claude.toml
+++ b/home/.chezmoidata/claude.toml
@@ -14,6 +14,7 @@
 caveman                   = "JuliusBrussee/caveman"
 "claude-brain-sync"       = "toroleapinc/claude-brain"
 "claude-plugins-official" = "anthropics/claude-plugins-official"
+"i-have-adhd"             = "ayghri/i-have-adhd"
 "karpathy-skills"         = "forrestchang/andrej-karpathy-skills"
 mattpocock                = "mattpocock/skills"
 "obsidian-skills"         = "kepano/obsidian-skills"
@@ -42,6 +43,12 @@ worktrunk                 = "max-sixty/worktrunk"
 "superpowers-extended-cc@superpowers-extended-cc-marketplace" = false
 "claude-code-setup@claude-plugins-official"        = true
 "security-guidance@claude-plugins-official"        = true
+# Output shaping, not dev tooling — wanted on every machine.
+# Upstream tag 0.1.0 added a redundant "hooks": "./hooks/hooks.json" to its
+# manifest, which Claude Code rejects ("Duplicate hooks file detected") since
+# hooks/hooks.json is auto-loaded. Until that is fixed upstream, a fresh install
+# needs the key removed from the cached manifest to load.
+"i-have-adhd@i-have-adhd"                          = true
 "explanatory-output-style@claude-plugins-official" = true
 "learning-output-style@claude-plugins-official"    = true
 "ralph-loop@claude-plugins-official"               = false


### PR DESCRIPTION
Installed ad-hoc on this Mac and on work-wsl, tracked by neither, so it never followed a new machine.

- Registers the `i-have-adhd` marketplace (`ayghri/i-have-adhd`)
- Enables `i-have-adhd@i-have-adhd` under `[plugins.always]` — it shapes output rather than providing dev tooling, so it belongs everywhere, not just dev machines

## Upstream load failure, recorded inline

Tag `0.1.0` added a redundant key to its manifest:

```json
"hooks": "./hooks/hooks.json"
```

Claude Code auto-loads `hooks/hooks.json` and rejects the duplicate:

```
Hook load failed: Duplicate hooks file detected ...
manifest.hooks should only reference additional hook files.
```

Commit-pinned installs predate the key and load fine — work-wsl runs `d1671755d416` without issue. A fresh install needs `.hooks` removed from the cached manifest until upstream drops it.

## Still outstanding, deliberately not in this PR

`run_onchange_before_10-install-brew-packages.sh.tmpl` and `dot_zshenv.tmpl` have unrelated uncommitted changes (a new `mas` list, added casks, a superwhisper env var). Left alone.